### PR TITLE
feat: declarative sources DSL (fetch/extract/lock) [v0.5.0]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,14 @@ on:
         required: false
         default: ""
         description: S3 bucket name for prod Lambda artifacts (master push only).
+    secrets:
+      sources_token:
+        required: false
+        description: >-
+          Token with read access to the private release repos referenced by any
+          github_release [[lambda.source]]. Exported as REPRO_LAMBDA_SOURCES_TOKEN for the
+          build. Omit when every source is a public https URL. Generic by design - the
+          reusable workflow never names a consumer repo.
 
 jobs:
   detect-arches:
@@ -64,6 +72,16 @@ jobs:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v8.2.0
 
+      # Content-addressed source cache, scoped per-arch (a source's sha256 is its key, so a
+      # re-pin changes the manifest hash -> fresh fetch; restore-keys reuses the prior cache).
+      - name: Cache fetched sources
+        uses: actions/cache@v4
+        with:
+          path: builds/.sources-cache
+          key: repro-sources-${{ matrix.arch }}-${{ hashFiles(inputs.manifest_path) }}
+          restore-keys: |
+            repro-sources-${{ matrix.arch }}-
+
       - name: Configure AWS credentials (dev)
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -73,6 +91,7 @@ jobs:
       - name: Build (dev bucket)
         env:
           REPRO_LAMBDA_BUCKET: ${{ inputs.dev_bucket }}
+          REPRO_LAMBDA_SOURCES_TOKEN: ${{ secrets.sources_token }}
         run: uvx --from repro-lambda repro-lambda build --manifest "${{ inputs.manifest_path }}" --arch "${{ matrix.arch }}"
 
       - name: Verify reproducible (PR only)
@@ -90,6 +109,7 @@ jobs:
         if: github.ref == 'refs/heads/master' && inputs.aws_prod_role_arn != ''
         env:
           REPRO_LAMBDA_BUCKET: ${{ inputs.prod_bucket }}
+          REPRO_LAMBDA_SOURCES_TOKEN: ${{ secrets.sources_token }}
         run: uvx --from repro-lambda repro-lambda build --manifest "${{ inputs.manifest_path }}" --arch "${{ matrix.arch }}"
 
       - name: Commit catalog drift (master only, dev bot)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.5.0 - 2026-06-21
+
+### Added
+- Declarative sources DSL: `[[lambda.source]]` fetches a pinned external artifact into the package before the container build, replacing consumer-side download scripts. Two source types - `github_release` (`repo`/`tag`/`asset`, resolved via the GitHub API) and `https` (a direct `url`). Each source is PINNED: `sha256` is verified before extraction; `extract` is `zip`/`tar.gz`/`none`; an optional `member` extracts a single file or a (versioned) directory subtree to `dest` (package-root-relative); `executable` sets +x. Source names are required and unique per lambda; dest collisions (including tree overlaps and overlaps with the staged source) are refused.
+- `version_from` (single-level): a source can derive its `version` at lock time from an asdf-style `key value` line in a referenced source's file (read relative to that source's member-stripped tree). `{version}` is substituted into `url`/`tag`/`asset`/`member`. `version_from` is a lock input and never participates in the content hash.
+- `lock --sources` re-resolves `version_from`, re-downloads each source, recomputes its sha256, and rewrites `lambdas.toml` in place with tomlkit (comments preserved, atomic). It is idempotent: a run that changes nothing leaves the file byte-for-byte unchanged (no spurious PR). `lock` keeps regenerating requirements locks too; use `--no-requirements` / `--no-sources` to scope it.
+- The reusable `build.yml` gains a generic `sources_token` secret (exported as `REPRO_LAMBDA_SOURCES_TOKEN`, used only for `github_release` API calls) and an arch-scoped `actions/cache` for the content-addressed source cache.
+
+### Security
+- SSRF-hardened fetcher: HTTPS-only with a manual redirect loop; each hop resolves the hostname, refuses any non-global-unicast / reserved / private / loopback / link-local / IPv4-mapped address, and connects to that pinned IP while verifying the TLS cert against the original hostname (no second DNS lookup a rebind could poison). `Authorization` is stripped on any cross-host redirect (e.g. the GitHub API -> asset host), so a private token never leaks. Download size is capped and log URLs are redacted (userinfo + query stripped).
+- Hardened extraction: sha256 is verified before any archive is opened; entries with absolute / `..` / symlink / hardlink / device / fifo paths are rejected; total bytes, entry count, and per-entry bytes are bounded (decompression-bomb limits, with streaming tar reads); files are written to a temp tree then promoted with normalized mtime + perms. The sha256-keyed cache is re-verified on every use (anti cache-poisoning).
+- Content hashing folds the RESOLVED source metadata (not the bytes), so the artifact key is computable offline and a `member`/`extract`/`dest`/`sha256`/version change re-keys, while a re-fetch alone does not.
+
 ## v0.4.2 - 2026-06-21
 
 ### Added

--- a/SETUP.md
+++ b/SETUP.md
@@ -330,6 +330,82 @@ The resolved per-lambda builder (base-image digest + include/exclude lists +
 builder version) folds into the content hash, so changing an override re-keys
 that lambda's artifact while leaving the others untouched.
 
+## Declarative sources — `[[lambda.source]]`
+
+A lambda can bundle pinned external artifacts (a release tarball, a vendored CLI
+binary) fetched at build time, instead of a hand-rolled download script. Each
+`[[lambda.source]]` is fully pinned and fetched + verified + extracted into the
+package before the container build:
+
+```toml
+[[lambda]]
+logical_name      = "app"
+source_dir        = "src/app"
+requirements_lock = "src/app/requirements.${arch}.lock"
+runtime           = "python3.13"
+arch              = "arm64"
+handler           = "app.lambda_handler"
+
+# A private GitHub release tarball -> staged at package path "vendor".
+[[lambda.source]]
+name    = "vendor"
+type    = "github_release"
+repo    = "owner/vendor-tool"
+tag     = "vendor-v{version}"
+asset   = "vendor-{version}.tar.gz"
+sha256  = "<64-hex; written by `repro-lambda lock`>"
+extract = "tar.gz"
+member  = "vendor-{version}"   # map the versioned top dir to dest
+dest    = "vendor"
+version = "1.4.0"              # bump this one line; lock re-pins everything
+
+# A public binary whose version is derived from the vendor release's .tool-versions.
+[[lambda.source]]
+name    = "terraform"
+type    = "https"
+url     = "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_linux_arm64.zip"
+sha256  = "<64-hex; written by lock>"
+extract = "zip"
+member  = "terraform"
+dest    = "bin/terraform"
+executable = true
+version = "1.9.0"
+[lambda.source.version_from]
+source = "vendor"          # read from the vendor source's extracted tree
+file   = ".tool-versions"  # relative to its member-stripped root
+key    = "terraform"
+```
+
+- **Pinning.** `sha256` is verified before the archive is opened. `extract` is
+  `zip` / `tar.gz` / `none`. `member` extracts one file or a directory subtree to
+  `dest`; omit it to extract the whole archive under `dest`. Source names are
+  unique per lambda and dests may not overlap each other or the staged source.
+- **`version_from`** (single-level) derives a source's `version` from an asdf-style
+  `key value` line in another source's file, so bumping the root `version`
+  cascades to dependents. It is a lock input - it never affects the artifact hash.
+- **`repro-lambda lock`** re-resolves `version_from`, re-downloads, recomputes each
+  `sha256`, and rewrites this file (comment-preserving, atomic, idempotent). Run it
+  after bumping a `version`. Pass `REPRO_LAMBDA_SOURCES_TOKEN` for private
+  `github_release` sources.
+- **Security.** Fetches are HTTPS-only with an SSRF guard (no private/loopback/
+  link-local/metadata IPs), strip `Authorization` on cross-host redirects, verify
+  sha256 before extraction, and reject path-traversal / link / device entries with
+  decompression-bomb bounds. See `src/repro_lambda/sources.py`.
+
+In CI, pass the token to the reusable `build.yml` as the `sources_token` secret:
+
+```yaml
+jobs:
+  build:
+    uses: antonbabenko/repro-lambda/.github/workflows/build.yml@v0
+    with:
+      manifest_path: lambdas.toml
+      aws_dev_role_arn: arn:aws:iam::<account>:role/<dev-builder-role>
+      dev_bucket: <env>-my-lambda-artifacts
+    secrets:
+      sources_token: ${{ secrets.MY_RELEASE_TOKEN }}
+```
+
 ## Terraform consumer — `s3_existing_package`
 
 In the Terraform that creates your Lambda function, point at the artifact in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repro-lambda"
-version = "0.4.2"
+version = "0.5.0"
 description = "Build reproducible AWS Lambda packages outside Terraform, optimized for terraform-aws-lambda by serverless.tf."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -21,7 +21,7 @@ dependencies = [
   "typer>=0.12",
   "repro-zipfile>=0.3.1",
   "boto3>=1.34",
-  
+  "tomlkit>=0.13",
 ]
 
 [project.optional-dependencies]

--- a/src/repro_lambda/__init__.py
+++ b/src/repro_lambda/__init__.py
@@ -1,3 +1,3 @@
 """repro-lambda — reproducible AWS Lambda packaging outside Terraform."""
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"

--- a/src/repro_lambda/build.py
+++ b/src/repro_lambda/build.py
@@ -88,6 +88,7 @@ def compute_sha_for(
             payload_exec=[(ef.dest, ef.executable) for ef in spec.extra_files],
             include_patterns=builder.include_patterns,
             exclude_patterns=builder.exclude_patterns,
+            sources=spec.sources,
         )
 
 
@@ -100,6 +101,8 @@ def build_one(
     catalog: Catalog,
     source_commit: str,
     dry_run: bool = False,
+    sources_token: str | None = None,
+    sources_cache: Path | None = None,
 ) -> BuildOutcome:
     """Build one lambda end-to-end. Returns BuildOutcome with sha + cache verdict."""
     builder = resolve_builder(builder, spec)
@@ -132,6 +135,7 @@ def build_one(
             payload_exec=[(ef.dest, ef.executable) for ef in spec.extra_files],
             include_patterns=builder.include_patterns,
             exclude_patterns=builder.exclude_patterns,
+            sources=spec.sources,
         )
         bucket_key = f"lambdas/{spec.logical_name}/{sha}.zip"
 
@@ -142,6 +146,18 @@ def build_one(
         if uploader.exists(bucket=target_bucket, key=bucket_key):
             _record(catalog, spec, sha, source_commit, builder)
             return BuildOutcome(BuildResult.CACHE_HIT, sha, bucket_key)
+
+        # Cache miss only: fetch + verify + extract declarative sources into the staged
+        # tree (post-filter; collides loudly with already-staged source/payload files).
+        if spec.sources:
+            from repro_lambda.sources import fetch_sources
+
+            fetch_sources(
+                sources=spec.sources,
+                dest_root=stage_dir / "source",
+                cache_dir=sources_cache or (repo_root / "builds" / ".sources-cache"),
+                github_token=sources_token,
+            )
 
         out_zip = stage_dir / "lambda.zip"
         if spec.package_manager == "pip":

--- a/src/repro_lambda/cli.py
+++ b/src/repro_lambda/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 from typing import Annotated
@@ -128,6 +129,8 @@ def build(
     except subprocess.CalledProcessError:
         source_commit = "unknown"
 
+    sources_token = os.environ.get("REPRO_LAMBDA_SOURCES_TOKEN") or None
+
     summary = []
     for spec in selected:
         outcome = build_one(
@@ -138,6 +141,7 @@ def build(
             catalog=catalog,
             source_commit=source_commit,
             dry_run=dry_run,
+            sources_token=sources_token,
         )
         summary.append(
             {
@@ -261,13 +265,39 @@ def promote(
 @app.command()
 def lock(
     manifest: Annotated[Path, typer.Option("--manifest", "-m")] = Path("lambdas.toml"),
+    requirements: Annotated[
+        bool,
+        typer.Option(
+            "--requirements/--no-requirements",
+            help="Regenerate per-arch requirements.${arch}.lock via uv pip compile.",
+        ),
+    ] = True,
+    sources: Annotated[
+        bool,
+        typer.Option(
+            "--sources/--no-sources",
+            help="Re-resolve version_from + re-pin [[lambda.source]] sha256 in the manifest.",
+        ),
+    ] = True,
 ) -> None:
-    """Regenerate per-arch requirements.${arch}.lock files via `uv pip compile`."""
+    """Lock pinned inputs: per-arch requirements locks and/or declarative source pins."""
     from repro_lambda.manifest import load_manifest
 
     parsed = load_manifest(manifest)
     repo_root = manifest.parent.resolve()
 
+    if requirements:
+        _lock_requirements(parsed, repo_root)
+
+    if sources:
+        from repro_lambda.source_locker import lock_sources
+
+        token = os.environ.get("REPRO_LAMBDA_SOURCES_TOKEN") or None
+        changed = lock_sources(manifest, token)
+        typer.echo(f"lock sources: {'updated ' + str(manifest) if changed else 'no changes'}")
+
+
+def _lock_requirements(parsed, repo_root: Path) -> None:
     for spec in parsed.lambdas:
         if spec.package_manager == "npm":
             typer.echo(

--- a/src/repro_lambda/hasher.py
+++ b/src/repro_lambda/hasher.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
-from repro_lambda.manifest import LambdaSpec
+from repro_lambda.manifest import LambdaSpec, Source
 
 
 def _sha256_file(path: Path) -> str:
@@ -27,6 +27,7 @@ def compute_content_hash(
     payload_exec: list[tuple[str, bool]] | None = None,
     include_patterns: list[str] | None = None,
     exclude_patterns: list[str] | None = None,
+    sources: tuple[Source, ...] | None = None,
 ) -> str:
     """
     sha256 over: sorted (relative-path, sha256(content)) tuples for the staged tree
@@ -46,6 +47,12 @@ def compute_content_hash(
     not re-key) and only when not None, so an explicit empty list (replace-with-empty)
     hashes differently from an unset/None filter. Callers passing None omit the
     section entirely, preserving hashes for code paths that do not resolve a builder.
+
+    sources are the declarative [[lambda.source]] entries. Their RESOLVED metadata
+    (the {version}-substituted url/tag/asset/member plus type/repo/extract/dest/
+    executable/sha256), sorted by name, folds in - NOT the downloaded bytes, so the
+    hash stays download-free. version_from is a lock input and never folded; a
+    member/extract/dest/sha256 change re-keys. Omitted entirely when there are none.
     """
     h = hashlib.sha256()
 
@@ -101,5 +108,23 @@ def compute_content_hash(
         h.update(b"---payload-exec---\n")
         for dest, executable in sorted(payload_exec):
             h.update(f"{dest}={int(executable)}\n".encode())
+
+    # Declarative sources: fold resolved metadata only (no bytes), sorted by name.
+    # version_from is intentionally excluded (it is a lock input, not artifact identity).
+    if sources:
+        h.update(b"---sources---\n")
+        for s in sorted(sources, key=lambda s: s.name):
+            h.update(f"name={s.name}\n".encode())
+            h.update(f"type={s.type}\n".encode())
+            h.update(f"repo={s.repo}\n".encode())
+            h.update(f"url={s.resolved_url}\n".encode())
+            h.update(f"tag={s.resolved_tag}\n".encode())
+            h.update(f"asset={s.resolved_asset}\n".encode())
+            h.update(f"member={s.resolved_member or ''}\n".encode())
+            h.update(f"extract={s.extract}\n".encode())
+            h.update(f"dest={s.dest}\n".encode())
+            h.update(f"executable={int(s.executable)}\n".encode())
+            h.update(f"sha256={s.sha256}\n".encode())
+            h.update(b"--\n")
 
     return h.hexdigest()

--- a/src/repro_lambda/manifest.py
+++ b/src/repro_lambda/manifest.py
@@ -35,6 +35,74 @@ class ExtraFile:
     executable: bool = False
 
 
+SUPPORTED_SOURCE_TYPES = {"github_release", "https"}
+SUPPORTED_EXTRACT = {"zip", "tar.gz", "none"}
+
+
+@dataclass(frozen=True)
+class VersionFrom:
+    """Lock-time version resolution rule for a source (never hashed).
+
+    At `lock` time the referenced source (`source`, by name) is fetched + extracted,
+    the asdf-style `<key> <value>` line is read from `file` (relative to that source's
+    extracted tree), and the value re-pins this source's `version`. `build` never
+    resolves this - it substitutes the already-locked `version` into the url/tag/asset
+    templates. Single-level only: the referenced source may not itself use version_from.
+    """
+
+    source: str
+    file: str
+    key: str
+
+
+@dataclass(frozen=True)
+class Source:
+    """A pinned external artifact fetched into the package before the container build.
+
+    Two types: `github_release` (private, asset resolved via the GitHub API then
+    downloaded) and `https` (public direct URL). Every source is PINNED: `sha256` is
+    verified before extraction, and the resolved metadata (not the bytes) is what folds
+    into the content hash. `extract` selects the archive handling (`zip`/`tar.gz`/`none`);
+    `member`, when set, extracts a single archive entry to `dest`, otherwise the whole
+    archive lands under `dest` (package-root-relative). `version`, when a `version_from`
+    rule is present, is the lock-written concrete version substituted into the url/tag/
+    asset templates' `{version}` placeholder at fetch + hash time.
+    """
+
+    name: str
+    type: str
+    sha256: str
+    extract: str
+    dest: str
+    repo: str = ""
+    tag: str = ""
+    asset: str = ""
+    url: str = ""
+    member: str | None = None
+    executable: bool = False
+    version: str = ""
+    version_from: VersionFrom | None = None
+
+    def _subst(self, value: str) -> str:
+        return value.replace("{version}", self.version) if self.version else value
+
+    @property
+    def resolved_url(self) -> str:
+        return self._subst(self.url)
+
+    @property
+    def resolved_tag(self) -> str:
+        return self._subst(self.tag)
+
+    @property
+    def resolved_asset(self) -> str:
+        return self._subst(self.asset)
+
+    @property
+    def resolved_member(self) -> str | None:
+        return self._subst(self.member) if self.member else self.member
+
+
 @dataclass(frozen=True)
 class LambdaSpec:
     logical_name: str
@@ -54,6 +122,7 @@ class LambdaSpec:
     base_image_python: str | None = None
     include_patterns: list[str] | None = None
     exclude_patterns: list[str] | None = None
+    sources: tuple[Source, ...] = ()
 
     @property
     def resolved_requirements_lock(self) -> str:
@@ -127,6 +196,185 @@ def _parse_extra_files(path: Path, entry: dict) -> tuple[ExtraFile, ...]:
     return tuple(parsed)
 
 
+def _validate_relpath(path: Path, field: str, value: str, *, where: str) -> None:
+    if value.startswith("/") or ".." in Path(value).parts:
+        raise ValueError(f"{path}: {where} {field}={value!r} must be a relative path without '..'")
+
+
+def _is_hex64(s: str) -> bool:
+    return len(s) == 64 and all(c in "0123456789abcdef" for c in s)
+
+
+def _paths_overlap(a: str, b: str) -> bool:
+    """True if two normalized package-relative paths are equal or one is a tree prefix
+    of the other (``a`` vs ``a/b``). Siblings (``a/b`` vs ``a/c``) do not overlap."""
+    if a == b:
+        return True
+    pa, pb = a.split("/"), b.split("/")
+    n = min(len(pa), len(pb))
+    return pa[:n] == pb[:n]
+
+
+def _reject_dest_overlaps(path: Path, named_dests: list[tuple[str, str]]) -> None:
+    norm = [(name, Path(d).as_posix().strip("/")) for name, d in named_dests]
+    for i in range(len(norm)):
+        for j in range(i + 1, len(norm)):
+            a_name, a = norm[i]
+            b_name, b = norm[j]
+            if _paths_overlap(a, b):
+                raise ValueError(
+                    f"{path}: source dest overlap between {a_name!r} ({a!r}) and "
+                    f"{b_name!r} ({b!r}); each source must stage to a disjoint subtree"
+                )
+
+
+def _parse_sources(path: Path, entry: dict) -> tuple[Source, ...]:
+    """Parse + validate a lambda's optional [[lambda.source]] entries."""
+    parsed: list[Source] = []
+    seen_names: set[str] = set()
+    lname = entry.get("logical_name")
+    for s in entry.get("source", []):
+        name = s.get("name", "")
+        if not name:
+            raise ValueError(f"{path}: each [[lambda.source]] requires a non-empty 'name'")
+        if name in seen_names:
+            raise ValueError(f"{path}: duplicate source name {name!r} in lambda {lname!r}")
+        seen_names.add(name)
+
+        stype = s.get("type", "")
+        if stype not in SUPPORTED_SOURCE_TYPES:
+            raise ValueError(
+                f"{path}: source {name!r} type must be one of "
+                f"{sorted(SUPPORTED_SOURCE_TYPES)} (got {stype!r})"
+            )
+
+        extract = s.get("extract", "")
+        if extract not in SUPPORTED_EXTRACT:
+            raise ValueError(
+                f"{path}: source {name!r} extract must be one of "
+                f"{sorted(SUPPORTED_EXTRACT)} (got {extract!r})"
+            )
+
+        dest = s.get("dest", "")
+        if not dest:
+            raise ValueError(f"{path}: source {name!r} requires a non-empty 'dest'")
+        _validate_relpath(path, "dest", dest, where=f"source {name!r}")
+
+        sha256 = s.get("sha256", "")
+        if sha256 and not _is_hex64(sha256):
+            raise ValueError(
+                f"{path}: source {name!r} sha256 must be 64 lowercase hex chars (got {sha256!r})"
+            )
+
+        member = s.get("member")
+        if member is not None:
+            if extract == "none":
+                raise ValueError(
+                    f"{path}: source {name!r} sets 'member' but extract='none' "
+                    f"(no archive to extract a member from)"
+                )
+            _validate_relpath(path, "member", member, where=f"source {name!r}")
+
+        repo = s.get("repo", "")
+        tag = s.get("tag", "")
+        asset = s.get("asset", "")
+        url = s.get("url", "")
+        if stype == "github_release":
+            for fn, fv in (("repo", repo), ("tag", tag), ("asset", asset)):
+                if not fv:
+                    raise ValueError(
+                        f"{path}: github_release source {name!r} requires non-empty {fn!r}"
+                    )
+            if repo.count("/") != 1 or repo.startswith("/") or repo.endswith("/"):
+                raise ValueError(
+                    f"{path}: github_release source {name!r} repo must be 'owner/name' "
+                    f"(got {repo!r})"
+                )
+            if url:
+                raise ValueError(
+                    f"{path}: github_release source {name!r} must not set 'url' "
+                    f"(it is resolved from repo/tag/asset)"
+                )
+        else:  # https
+            if not url:
+                raise ValueError(f"{path}: https source {name!r} requires non-empty 'url'")
+            if not url.startswith("https://"):
+                raise ValueError(
+                    f"{path}: https source {name!r} url must start with https:// (got {url!r})"
+                )
+            for fn, fv in (("repo", repo), ("tag", tag), ("asset", asset)):
+                if fv:
+                    raise ValueError(
+                        f"{path}: https source {name!r} must not set {fn!r} (use 'url')"
+                    )
+
+        version = s.get("version", "")
+        vf_raw = s.get("version_from")
+        version_from = None
+        if vf_raw is not None:
+            for fn in ("source", "file", "key"):
+                if not vf_raw.get(fn):
+                    raise ValueError(
+                        f"{path}: source {name!r} version_from requires non-empty {fn!r}"
+                    )
+            if vf_raw["source"] == name:
+                raise ValueError(
+                    f"{path}: source {name!r} version_from.source cannot reference itself"
+                )
+            _validate_relpath(path, "version_from.file", vf_raw["file"], where=f"source {name!r}")
+            version_from = VersionFrom(
+                source=vf_raw["source"], file=vf_raw["file"], key=vf_raw["key"]
+            )
+
+        uses_template = any("{version}" in v for v in (url, tag, asset, member or ""))
+        if uses_template and not version and version_from is None:
+            raise ValueError(
+                f"{path}: source {name!r} uses '{{version}}' but has no 'version' value or "
+                f"[lambda.source.version_from] rule to resolve it"
+            )
+
+        parsed.append(
+            Source(
+                name=name,
+                type=stype,
+                sha256=sha256,
+                extract=extract,
+                dest=dest,
+                repo=repo,
+                tag=tag,
+                asset=asset,
+                url=url,
+                member=member,
+                executable=bool(s.get("executable", False)),
+                version=version,
+                version_from=version_from,
+            )
+        )
+
+    by_name = {src.name: src for src in parsed}
+    for src in parsed:
+        if src.version_from is None:
+            continue
+        ref = src.version_from.source
+        if ref not in by_name:
+            raise ValueError(
+                f"{path}: source {src.name!r} version_from.source={ref!r} is not a defined source"
+            )
+        if by_name[ref].version_from is not None:
+            raise ValueError(
+                f"{path}: source {src.name!r} version_from.source={ref!r} is itself "
+                f"version_from-resolved (single-level only)"
+            )
+        if by_name[ref].extract == "none":
+            raise ValueError(
+                f"{path}: source {src.name!r} version_from.source={ref!r} has extract='none'; "
+                f"a referenced source must be an archive to read its version file"
+            )
+
+    _reject_dest_overlaps(path, [(src.name, src.dest) for src in parsed])
+    return tuple(parsed)
+
+
 def load_manifest(path: Path) -> Manifest:
     """Parse lambdas.toml and validate semantic invariants."""
     with path.open("rb") as f:
@@ -184,6 +432,7 @@ def load_manifest(path: Path) -> Manifest:
             )
 
         extra_files = _parse_extra_files(path, entry)
+        sources = _parse_sources(path, entry)
 
         override_base_image = entry.get("base_image_python")
         if override_base_image is not None and "@sha256:" not in override_base_image:
@@ -222,6 +471,7 @@ def load_manifest(path: Path) -> Manifest:
                 base_image_python=override_base_image,
                 include_patterns=list(override_include) if override_include is not None else None,
                 exclude_patterns=list(override_exclude) if override_exclude is not None else None,
+                sources=sources,
             )
         )
 

--- a/src/repro_lambda/source_locker.py
+++ b/src/repro_lambda/source_locker.py
@@ -1,0 +1,149 @@
+"""`lock` for declarative sources: resolve version_from, re-pin sha256, rewrite toml.
+
+This is the ONLY code that resolves a source's version and recomputes its sha256. It
+runs deliberately (a human or a scheduled job), never on the build path. The rewrite is
+comment-preserving (tomlkit) and atomic; a run that changes nothing leaves the file
+untouched and reports no change (so a scheduled job opens no empty PR).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import tomlkit
+
+from repro_lambda.manifest import Source, load_manifest
+from repro_lambda.sources import (
+    SourceFetchError,
+    download_unverified,
+    extract_to_temp,
+)
+
+_MAX_VERSION_FILE_BYTES = 1024 * 1024  # an asdf .tool-versions is tiny; cap to be safe
+
+
+@dataclass
+class SourcePin:
+    """The re-resolved pin for one source (what lock writes back)."""
+
+    name: str
+    sha256: str
+    version: str  # "" when the source has no version_from
+    changed: bool
+
+
+def _read_asdf_version(path: Path, key: str) -> str:
+    """Read `<key> <value>` from an asdf-style file (e.g. .tool-versions)."""
+    if not path.is_file():
+        raise SourceFetchError(f"version_from file not found: {path}")
+    if path.stat().st_size > _MAX_VERSION_FILE_BYTES:
+        raise SourceFetchError(f"version_from file too large: {path}")
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) >= 2 and parts[0] == key:
+            return parts[1]
+    raise SourceFetchError(f"key {key!r} not found in {path.name}")
+
+
+def _ordered(sources: tuple[Source, ...]) -> list[Source]:
+    """Non-version_from sources first (the referenced roots), then dependents.
+
+    version_from is single-level (validated at load), so this two-pass order guarantees a
+    referenced source is fetched + extracted before any source that reads its version.
+    """
+    return [s for s in sources if s.version_from is None] + [
+        s for s in sources if s.version_from is not None
+    ]
+
+
+def _lock_lambda_sources(
+    sources: tuple[Source, ...], token: str | None, tmp: Path
+) -> dict[str, SourcePin]:
+    """Re-resolve + re-pin every source of one lambda. Returns pins keyed by name."""
+    tmp.mkdir(parents=True, exist_ok=True)
+    src_by_name = {s.name: s for s in sources}
+    pins: dict[str, SourcePin] = {}
+    extracted: dict[str, Path] = {}
+    for src in _ordered(sources):
+        version = src.version
+        if src.version_from is not None:
+            ref = src.version_from.source
+            if ref not in extracted:
+                raise SourceFetchError(
+                    f"source {src.name!r}: referenced source {ref!r} was not extracted "
+                    f"(it must declare an archive extract)"
+                )
+            # Read relative to the referenced source's member-stripped tree, so file= can
+            # be e.g. ".tool-versions" rather than the version-dependent "pofix-9.9/...".
+            base = extracted[ref]
+            ref_member = src_by_name[ref].resolved_member
+            if ref_member:
+                base = base / ref_member
+            version = _read_asdf_version(base / src.version_from.file, src.version_from.key)
+        resolved = replace(src, version=version)
+
+        raw = tmp / f"lock-{src.name}"
+        new_sha = download_unverified(resolved, token, raw)
+
+        if resolved.extract != "none":
+            extracted[src.name] = extract_to_temp(raw, resolved.extract, tmp / f"x-{src.name}")
+
+        changed = new_sha != src.sha256 or version != src.version
+        pins[src.name] = SourcePin(
+            name=src.name,
+            sha256=new_sha,
+            version=version if src.version_from is not None else "",
+            changed=changed,
+        )
+    return pins
+
+
+def _apply_pins(doc: tomlkit.TOMLDocument, all_pins: list[dict[str, SourcePin]]) -> None:
+    """Write the re-pinned sha256 (+ version for version_from sources) into the toml doc."""
+    lambdas = doc.get("lambda", [])
+    for li, lam in enumerate(lambdas):
+        pins = all_pins[li]
+        for st in lam.get("source", []):
+            pin = pins.get(st["name"])
+            if pin is None:
+                continue
+            st["sha256"] = pin.sha256
+            if pin.version:  # only version_from sources carry a locked version
+                st["version"] = pin.version
+
+
+def lock_sources(manifest_path: Path, github_token: str | None) -> bool:
+    """Re-resolve + re-pin all sources across the manifest. Returns True if it changed.
+
+    A False return means every pin was already current: the file is left byte-for-byte
+    unchanged (idempotent; no spurious PR from a scheduled run).
+    """
+    parsed = load_manifest(manifest_path)
+    if not any(spec.sources for spec in parsed.lambdas):
+        return False
+
+    all_pins: list[dict[str, SourcePin]] = []
+    with tempfile.TemporaryDirectory(prefix="repro-lock-") as td:
+        tmp = Path(td)
+        for spec in parsed.lambdas:
+            all_pins.append(
+                _lock_lambda_sources(spec.sources, github_token, tmp / spec.logical_name)
+                if spec.sources
+                else {}
+            )
+
+    if not any(pin.changed for pins in all_pins for pin in pins.values()):
+        return False
+
+    doc = tomlkit.parse(manifest_path.read_text(encoding="utf-8"))
+    _apply_pins(doc, all_pins)
+    staging = manifest_path.with_name(manifest_path.name + ".lock.tmp")
+    staging.write_text(tomlkit.dumps(doc), encoding="utf-8")
+    os.replace(staging, manifest_path)
+    return True

--- a/src/repro_lambda/sources.py
+++ b/src/repro_lambda/sources.py
@@ -1,0 +1,465 @@
+"""Fetch, verify, and extract pinned external sources (the declarative sources DSL).
+
+Security model (defense in depth; see SETUP.md "Sources"):
+
+- HTTPS only. A manual redirect loop resolves each hop's hostname to an IP, rejects any
+  non-global-unicast / reserved / private / loopback / link-local address (SSRF guard),
+  and connects to that pinned IP while verifying the TLS cert against the original
+  hostname - so a DNS-rebind between validate and connect cannot occur.
+- `Authorization` is stripped on any cross-host redirect (e.g. the GitHub API 302 to its
+  S3/Blob asset host), so a private token never leaks to a redirect target.
+- The downloaded bytes are sha256-verified BEFORE any archive is opened. The cache is
+  keyed by that sha256 and re-verified on every use (anti cache-poisoning).
+- Extraction rejects absolute / `..` / symlink / hardlink / device / fifo entries and
+  bounds total bytes, entry count, per-entry bytes (decompression-bomb limits), writing
+  to a temp dir then promoting into place. Members get a normalized mtime + perms.
+
+`build` calls `fetch_sources` with concrete pins only (it never resolves versions);
+`lock` is the only path that re-resolves `version_from` and re-pins sha256.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import ipaddress
+import json
+import os
+import shutil
+import socket
+import ssl
+import tarfile
+import tempfile
+import zipfile
+from http.client import HTTPSConnection
+from pathlib import Path
+from urllib.parse import urljoin, urlsplit, urlunsplit
+
+from repro_lambda.manifest import Source
+
+# Limits (decompression-bomb + DoS bounds). Generous enough for real release artifacts.
+MAX_DOWNLOAD_BYTES = 1024 * 1024 * 1024  # 1 GiB compressed download cap
+MAX_TOTAL_UNCOMPRESSED = 2 * 1024 * 1024 * 1024  # 2 GiB extracted cap
+MAX_PER_ENTRY_BYTES = 1024 * 1024 * 1024  # 1 GiB per archive entry
+MAX_ARCHIVE_ENTRIES = 50_000
+MAX_REDIRECTS = 5
+HTTP_TIMEOUT = 60  # seconds per hop
+_GITHUB_API = "https://api.github.com"
+_JSON_MAX_BYTES = 16 * 1024 * 1024
+_CHUNK = 64 * 1024
+
+
+class SourceFetchError(RuntimeError):
+    """A source could not be fetched, verified, or extracted."""
+
+
+class SourceSecurityError(SourceFetchError):
+    """A fetch/extract was refused by a security guard (SSRF, traversal, bomb, mismatch)."""
+
+
+# --- SSRF-safe HTTPS -------------------------------------------------------
+
+
+def _redact(url: str) -> str:
+    """URL safe for logs: scheme://host[:port]/path, dropping userinfo + query."""
+    p = urlsplit(url)
+    netloc = p.hostname or ""
+    if p.port:
+        netloc = f"{netloc}:{p.port}"
+    return urlunsplit((p.scheme, netloc, p.path, "", ""))
+
+
+def _is_ip_literal(host: str) -> bool:
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_public_ip(ip_str: str) -> bool:
+    ip = ipaddress.ip_address(ip_str)
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped  # validate the embedded v4 of ::ffff:a.b.c.d
+    return ip.is_global and not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def _resolve_public_ip(host: str) -> str:
+    """Resolve host to a single vetted public IP, or refuse. Connection pins this IP."""
+    try:
+        infos = socket.getaddrinfo(host, 443, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        raise SourceFetchError(f"DNS resolution failed for {host!r}: {e}") from e
+    for info in infos:
+        ip = info[4][0]
+        if _is_public_ip(ip):
+            return ip
+    raise SourceSecurityError(f"{host!r} resolves only to non-public addresses; refusing")
+
+
+class _PinnedHTTPSConnection(HTTPSConnection):
+    """HTTPSConnection that connects to a pre-validated IP but keeps the hostname for
+    SNI + certificate verification (no second DNS lookup that a rebind could poison)."""
+
+    def __init__(self, host: str, pinned_ip: str, **kw):
+        super().__init__(host, **kw)
+        self._pinned_ip = pinned_ip
+
+    def connect(self) -> None:
+        sock = socket.create_connection((self._pinned_ip, self.port), self.timeout)
+        self.sock = self.context.wrap_socket(sock, server_hostname=self.host)
+
+
+def _http_request(
+    url: str, headers: dict[str, str], sink: io.BufferedWriter, max_bytes: int
+) -> str:
+    """GET url following redirects under the SSRF guard; stream body into sink.
+
+    Returns the sha256 of the streamed body. Strips Authorization on any cross-host hop.
+    """
+    origin_host = urlsplit(url).hostname
+    context = ssl.create_default_context()
+    current = url
+    for _hop in range(MAX_REDIRECTS + 1):
+        parts = urlsplit(current)
+        if parts.scheme != "https":
+            raise SourceSecurityError(f"non-https URL refused: {_redact(current)}")
+        host = parts.hostname
+        if not host or _is_ip_literal(host):
+            raise SourceSecurityError(f"IP-literal or missing host refused: {_redact(current)}")
+        pinned_ip = _resolve_public_ip(host)
+        req_headers = dict(headers)
+        if host != origin_host:  # crossed hosts (e.g. api.github.com -> codeload/S3)
+            req_headers.pop("Authorization", None)
+        conn = _PinnedHTTPSConnection(host, pinned_ip, port=parts.port or 443, timeout=HTTP_TIMEOUT)
+        conn.context = context
+        try:
+            target = parts.path + (f"?{parts.query}" if parts.query else "")
+            conn.request("GET", target or "/", headers={**req_headers, "Host": host})
+            resp = conn.getresponse()
+            if resp.status in (301, 302, 303, 307, 308):
+                location = resp.getheader("Location")
+                resp.read()
+                if not location:
+                    raise SourceFetchError(f"redirect without Location from {_redact(current)}")
+                current = urljoin(current, location)
+                continue
+            if resp.status != 200:
+                raise SourceFetchError(f"GET {_redact(current)} -> HTTP {resp.status}")
+            return _stream_to(resp, sink, max_bytes)
+        finally:
+            conn.close()
+    raise SourceFetchError(f"too many redirects fetching {_redact(url)}")
+
+
+def _stream_to(resp, sink: io.BufferedWriter, max_bytes: int) -> str:
+    h = hashlib.sha256()
+    total = 0
+    while True:
+        chunk = resp.read(_CHUNK)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise SourceSecurityError(f"download exceeds {max_bytes} bytes; aborting")
+        h.update(chunk)
+        sink.write(chunk)
+    return h.hexdigest()
+
+
+def _http_get_json(url: str, headers: dict[str, str]) -> dict:
+    buf = io.BytesIO()
+    writer = io.BufferedWriter(_RawSink(buf))
+    _http_request(url, headers, writer, _JSON_MAX_BYTES)
+    writer.flush()
+    return json.loads(buf.getvalue().decode("utf-8"))
+
+
+class _RawSink(io.RawIOBase):
+    """Adapt a BytesIO to the BufferedWriter sink interface used by _http_request."""
+
+    def __init__(self, buf: io.BytesIO):
+        self._buf = buf
+
+    def writable(self) -> bool:
+        return True
+
+    def write(self, b) -> int:
+        return self._buf.write(b)
+
+
+# --- GitHub release asset resolution --------------------------------------
+
+
+def _github_asset_url(src: Source, token: str | None) -> tuple[str, dict[str, str]]:
+    """Resolve a github_release source to its asset download URL + auth headers."""
+    if not token:
+        raise SourceFetchError(
+            f"source {src.name!r} is github_release but no token provided "
+            f"(set REPRO_LAMBDA_SOURCES_TOKEN)"
+        )
+    tag = src.resolved_tag
+    api = f"{_GITHUB_API}/repos/{src.repo}/releases/tags/{tag}"
+    auth = {"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json"}
+    release = _http_get_json(api, auth)
+    want = src.resolved_asset
+    for asset in release.get("assets", []):
+        if asset.get("name") == want:
+            asset_id = asset["id"]
+            dl = f"{_GITHUB_API}/repos/{src.repo}/releases/assets/{asset_id}"
+            return dl, {"Authorization": f"Bearer {token}", "Accept": "application/octet-stream"}
+    raise SourceFetchError(f"source {src.name!r}: asset {want!r} not found in {src.repo}@{tag}")
+
+
+# --- download + cache ------------------------------------------------------
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(_CHUNK), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _fetch_verified(src: Source, cache_dir: Path, token: str | None, tmp: Path) -> Path:
+    """Return a path to the sha256-verified raw bytes for src (cache hit or download)."""
+    cached = cache_dir / f"{src.sha256}.bin"
+    if cached.is_file():
+        if _sha256_file(cached) == src.sha256:  # re-verify every use (anti-poisoning)
+            return cached
+        cached.unlink()  # corrupt/poisoned cache entry; re-download
+
+    if src.type == "github_release":
+        url, headers = _github_asset_url(src, token)
+    else:
+        url, headers = src.resolved_url, {}
+
+    staging = tmp / f"dl-{src.name}"
+    with staging.open("wb") as raw:  # binary "wb" handle is already a buffered writer
+        actual = _http_request(url, headers, raw, MAX_DOWNLOAD_BYTES)
+    if actual != src.sha256:
+        staging.unlink(missing_ok=True)
+        raise SourceSecurityError(
+            f"source {src.name!r} sha256 mismatch: expected {src.sha256}, got {actual} "
+            f"(from {_redact(url)})"
+        )
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    os.replace(staging, cached)
+    return cached
+
+
+# --- safe extraction -------------------------------------------------------
+
+
+def _safe_join(base: Path, rel: str) -> Path:
+    base = base.resolve()
+    target = (base / rel).resolve()
+    if target != base and base not in target.parents:
+        raise SourceSecurityError(f"path escapes destination: {rel!r}")
+    return target
+
+
+def _reject_unsafe_name(name: str) -> None:
+    if name.startswith("/") or name.startswith("\\") or ".." in Path(name).parts:
+        raise SourceSecurityError(f"unsafe archive entry name: {name!r}")
+
+
+def _copy_capped(src, dst, limit: int) -> None:
+    written = 0
+    while True:
+        chunk = src.read(_CHUNK)
+        if not chunk:
+            break
+        written += len(chunk)
+        if written > limit:
+            raise SourceSecurityError("archive entry exceeds declared/allowed size (bomb)")
+        dst.write(chunk)
+
+
+def _normalize(path: Path, executable: bool) -> None:
+    mode = 0o755 if executable else 0o644
+    path.chmod(mode)
+    os.utime(path, (0, 0))
+
+
+class _LimitingReader(io.RawIOBase):
+    """Bounds total bytes pulled through a (decompressed) stream - tar-bomb guard."""
+
+    def __init__(self, fileobj, max_bytes: int):
+        self._f = fileobj
+        self._max = max_bytes
+        self._count = 0
+
+    def readable(self) -> bool:
+        return True
+
+    def read(self, size: int = -1) -> bytes:
+        chunk = self._f.read(size)
+        self._count += len(chunk)
+        if self._count > self._max:
+            raise SourceSecurityError("decompressed size exceeds limit (tar bomb)")
+        return chunk
+
+    def readinto(self, b) -> int:
+        chunk = self.read(len(b))
+        n = len(chunk)
+        b[:n] = chunk
+        return n
+
+
+def _extract_zip(raw_path: Path, out_dir: Path) -> None:
+    with zipfile.ZipFile(raw_path) as zf:
+        infos = zf.infolist()
+        if len(infos) > MAX_ARCHIVE_ENTRIES:
+            raise SourceSecurityError(f"archive has too many entries ({len(infos)})")
+        total = 0
+        for info in sorted(infos, key=lambda i: i.filename):
+            _reject_unsafe_name(info.filename)
+            if _zip_is_symlink(info):
+                raise SourceSecurityError(f"symlink entry rejected: {info.filename!r}")
+            target = _safe_join(out_dir, info.filename)
+            if info.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if info.file_size > MAX_PER_ENTRY_BYTES:
+                raise SourceSecurityError(f"entry too large: {info.filename!r}")
+            total += info.file_size
+            if total > MAX_TOTAL_UNCOMPRESSED:
+                raise SourceSecurityError("archive exceeds total uncompressed limit (bomb)")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info) as src, target.open("wb") as dst:
+                _copy_capped(src, dst, min(info.file_size, MAX_PER_ENTRY_BYTES))
+            _normalize(target, executable=False)
+
+
+def _zip_is_symlink(info: zipfile.ZipInfo) -> bool:
+    # Unix mode lives in the high 16 bits of external_attr; S_IFLNK == 0o120000.
+    return (info.external_attr >> 16) & 0o170000 == 0o120000
+
+
+def _extract_targz(raw_path: Path, out_dir: Path) -> None:
+    with raw_path.open("rb") as raw, gzip.GzipFile(fileobj=raw) as gz:
+        limited = _LimitingReader(gz, MAX_TOTAL_UNCOMPRESSED)
+        count = 0
+        with tarfile.open(fileobj=limited, mode="r|") as tf:  # streaming (no seek/backref)
+            for member in tf:
+                count += 1
+                if count > MAX_ARCHIVE_ENTRIES:
+                    raise SourceSecurityError("archive has too many entries")
+                _reject_unsafe_name(member.name)
+                if member.issym() or member.islnk():
+                    raise SourceSecurityError(f"link entry rejected: {member.name!r}")
+                if member.ischr() or member.isblk() or member.isfifo() or member.isdev():
+                    raise SourceSecurityError(f"special entry rejected: {member.name!r}")
+                target = _safe_join(out_dir, member.name)
+                if member.isdir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                if not member.isfile():
+                    raise SourceSecurityError(f"unsupported entry type: {member.name!r}")
+                if member.size > MAX_PER_ENTRY_BYTES:
+                    raise SourceSecurityError(f"entry too large: {member.name!r}")
+                target.parent.mkdir(parents=True, exist_ok=True)
+                extracted = tf.extractfile(member)
+                if extracted is None:
+                    raise SourceFetchError(f"could not read entry: {member.name!r}")
+                with extracted as src, target.open("wb") as dst:
+                    _copy_capped(src, dst, min(member.size, MAX_PER_ENTRY_BYTES))
+                _normalize(target, executable=False)
+
+
+def _extract_to_temp(raw_path: Path, kind: str, parent: Path) -> Path:
+    out = parent / "extracted"
+    out.mkdir(parents=True, exist_ok=True)
+    if kind == "zip":
+        _extract_zip(raw_path, out)
+    elif kind == "tar.gz":
+        _extract_targz(raw_path, out)
+    else:
+        raise SourceFetchError(f"unknown extract kind: {kind!r}")
+    return out
+
+
+# --- staging into the package ----------------------------------------------
+
+
+def _stage(src: Source, raw_path: Path, extracted: Path | None, dest_root: Path) -> None:
+    target = _safe_join(dest_root, src.dest)
+    if target.exists():  # source-vs-source or source-vs-source_dir collision
+        raise SourceFetchError(
+            f"source {src.name!r} dest {src.dest!r} collides with already-staged content"
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if src.extract == "none":
+        shutil.copyfile(raw_path, target)
+        _normalize(target, src.executable)
+    elif src.member:
+        member_path = _safe_join(extracted, src.resolved_member)  # type: ignore[arg-type]
+        if member_path.is_dir():  # map a (versioned) subtree to dest
+            shutil.copytree(member_path, target)
+        elif member_path.is_file():
+            shutil.copyfile(member_path, target)
+            _normalize(target, src.executable)
+        else:
+            raise SourceFetchError(
+                f"source {src.name!r}: member {src.resolved_member!r} not found in archive"
+            )
+    else:
+        shutil.copytree(extracted, target)  # type: ignore[arg-type]
+
+
+def download_unverified(src: Source, token: str | None, dest_path: Path) -> str:
+    """Download a source's resolved artifact (no sha pin) and return its sha256.
+
+    Used by `lock`, which is computing the new pin and therefore has no sha to verify
+    against yet. The SSRF guard, redirect auth-strip, and size cap still apply.
+    """
+    if src.type == "github_release":
+        url, headers = _github_asset_url(src, token)
+    else:
+        url, headers = src.resolved_url, {}
+    with dest_path.open("wb") as raw:
+        return _http_request(url, headers, raw, MAX_DOWNLOAD_BYTES)
+
+
+def extract_to_temp(raw_path: Path, kind: str, parent: Path) -> Path:
+    """Public wrapper so `lock` can extract a referenced source to read version_from."""
+    return _extract_to_temp(raw_path, kind, parent)
+
+
+def fetch_sources(
+    *,
+    sources: tuple[Source, ...],
+    dest_root: Path,
+    cache_dir: Path,
+    github_token: str | None,
+) -> None:
+    """Fetch + verify + extract each source into dest_root/<dest>. Concrete pins only.
+
+    All-or-none in practice: any failure raises, and the caller stages into an ephemeral
+    tree that is discarded on error. Sources are post-filter (include/exclude do not apply).
+    """
+    if not sources:
+        return
+    with tempfile.TemporaryDirectory(prefix="repro-sources-") as td:
+        tmp = Path(td)
+        for src in sources:
+            if not src.sha256:
+                raise SourceFetchError(
+                    f"source {src.name!r} has no pinned sha256; run `repro-lambda lock` first"
+                )
+            raw = _fetch_verified(src, cache_dir, github_token, tmp)
+            extracted = None
+            if src.extract != "none":
+                extracted = _extract_to_temp(raw, src.extract, tmp / f"x-{src.name}")
+            _stage(src, raw, extracted, dest_root)

--- a/tests/test_source_locker.py
+++ b/tests/test_source_locker.py
@@ -1,0 +1,137 @@
+"""lock_sources: version_from resolution, sha re-pin, idempotent tomlkit rewrite."""
+
+import hashlib
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+from repro_lambda import source_locker
+from repro_lambda.manifest import load_manifest
+from repro_lambda.source_locker import lock_sources
+
+OLD_SHA = "0" * 64
+
+
+def _targz(path: Path, files: list[tuple[str, bytes]]) -> bytes:
+    with tarfile.open(path, "w:gz") as tf:
+        for name, data in files:
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return path.read_bytes()
+
+
+def _zip(path: Path, entries: list[tuple[str, bytes]]) -> bytes:
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in entries:
+            zf.writestr(name, data)
+    return path.read_bytes()
+
+
+def _manifest(tmp_path: Path) -> Path:
+    p = tmp_path / "lambdas.toml"
+    p.write_text(
+        "# keep this comment\n"
+        "[[lambda]]\n"
+        'logical_name      = "pofix_lambda"\n'
+        'source_dir        = "src/pofix"\n'
+        'requirements_lock = "src/pofix/requirements.${arch}.lock"\n'
+        'runtime           = "python3.13"\n'
+        'arch              = "arm64"\n'
+        'handler           = "handler.lambda_handler"\n'
+        "\n"
+        "[[lambda.source]]\n"
+        'name    = "pofix"\n'
+        'type    = "https"\n'
+        'url     = "https://example.com/pofix-{version}.tar.gz"\n'
+        f'sha256  = "{OLD_SHA}"\n'
+        'extract = "tar.gz"\n'
+        'member  = "pofix-{version}"\n'
+        'dest    = "pofix"\n'
+        'version = "9.9"\n'
+        "\n"
+        "[[lambda.source]]\n"
+        'name    = "terraform"\n'
+        'type    = "https"\n'
+        'url     = "https://example.com/terraform_{version}_linux_arm64.zip"\n'
+        f'sha256  = "{OLD_SHA}"\n'
+        'extract = "zip"\n'
+        'member  = "terraform"\n'
+        'dest    = "bin/terraform"\n'
+        'version = "0.0.0"\n'  # stale; lock derives it from pofix's .tool-versions
+        "[lambda.source.version_from]\n"
+        'source = "pofix"\n'
+        'file   = ".tool-versions"\n'
+        'key    = "terraform"\n'
+        "\n[builder]\n"
+        f'base_image_python = "public.ecr.aws/lambda/python:3.13@sha256:{"0" * 64}"\n'
+    )
+    return p
+
+
+def _fixtures(tmp_path: Path) -> dict[str, bytes]:
+    pofix = _targz(
+        tmp_path / "pofix.tgz",
+        [("pofix-9.9/.tool-versions", b"terraform 1.9.0\nhcledit 0.2.17\n")],
+    )
+    tf = _zip(tmp_path / "tf.zip", [("terraform", b"TFBINARY")])
+    return {"pofix": pofix, "terraform": tf}
+
+
+def _install_fake_download(monkeypatch, fixtures: dict[str, bytes]):
+    def _fake(src, token, dest_path):
+        data = fixtures[src.name]
+        dest_path.write_bytes(data)
+        return hashlib.sha256(data).hexdigest()
+
+    monkeypatch.setattr(source_locker, "download_unverified", _fake)
+
+
+def test_lock_resolves_version_from_and_repins(tmp_path, monkeypatch):
+    manifest = _manifest(tmp_path)
+    fixtures = _fixtures(tmp_path)
+    _install_fake_download(monkeypatch, fixtures)
+
+    changed = lock_sources(manifest, None)
+    assert changed is True
+
+    reloaded = load_manifest(manifest).lambdas[0]
+    by_name = {s.name: s for s in reloaded.sources}
+    assert by_name["terraform"].version == "1.9.0"  # derived from pofix .tool-versions
+    assert by_name["terraform"].sha256 == hashlib.sha256(fixtures["terraform"]).hexdigest()
+    assert by_name["pofix"].sha256 == hashlib.sha256(fixtures["pofix"]).hexdigest()
+    assert by_name["pofix"].version == "9.9"  # root version untouched by lock
+
+
+def test_lock_preserves_comments(tmp_path, monkeypatch):
+    manifest = _manifest(tmp_path)
+    _install_fake_download(monkeypatch, _fixtures(tmp_path))
+    lock_sources(manifest, None)
+    assert "# keep this comment" in manifest.read_text()
+
+
+def test_lock_is_idempotent(tmp_path, monkeypatch):
+    manifest = _manifest(tmp_path)
+    _install_fake_download(monkeypatch, _fixtures(tmp_path))
+
+    assert lock_sources(manifest, None) is True  # first run pins
+    before = manifest.read_text()
+    assert lock_sources(manifest, None) is False  # nothing to change
+    assert manifest.read_text() == before  # byte-for-byte unchanged -> no PR
+
+
+def test_lock_no_sources_returns_false(tmp_path):
+    p = tmp_path / "lambdas.toml"
+    p.write_text(
+        "[[lambda]]\n"
+        'logical_name      = "app"\n'
+        'source_dir        = "h"\n'
+        'requirements_lock = "h/requirements.${arch}.lock"\n'
+        'runtime           = "python3.13"\n'
+        'arch              = "arm64"\n'
+        'handler           = "app.lambda_handler"\n'
+        "\n[builder]\n"
+        f'base_image_python = "public.ecr.aws/lambda/python:3.13@sha256:{"0" * 64}"\n'
+    )
+    assert lock_sources(p, None) is False

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,442 @@
+"""Security + behavior tests for sources.py (SSRF guard, extractor, cache, staging)."""
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from repro_lambda import sources
+from repro_lambda.manifest import Source
+from repro_lambda.sources import (
+    SourceFetchError,
+    SourceSecurityError,
+    fetch_sources,
+)
+
+SHA_PLACEHOLDER = "a" * 64
+
+
+# --- IP / host guards ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "8.8.8.8",
+        "1.1.1.1",
+        "93.184.216.34",
+        "2606:4700:4700::1111",
+    ],
+)
+def test_public_ips_allowed(ip):
+    assert sources._is_public_ip(ip) is True
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "127.0.0.1",
+        "169.254.169.254",  # cloud metadata
+        "10.0.0.1",
+        "172.16.5.5",
+        "192.168.1.1",
+        "100.64.0.1",  # CGNAT
+        "0.0.0.0",
+        "::1",
+        "fe80::1",
+        "fc00::1",
+        "::ffff:127.0.0.1",  # IPv4-mapped loopback
+        "::ffff:169.254.169.254",  # IPv4-mapped metadata
+    ],
+)
+def test_reserved_ips_refused(ip):
+    assert sources._is_public_ip(ip) is False
+
+
+def test_is_ip_literal():
+    assert sources._is_ip_literal("1.2.3.4") is True
+    assert sources._is_ip_literal("::1") is True
+    assert sources._is_ip_literal("example.com") is False
+
+
+def test_redact_strips_userinfo_and_query():
+    red = sources._redact("https://user:pw@host.example/path?token=secret&x=1")
+    assert red == "https://host.example/path"
+    assert "secret" not in red and "user" not in red
+
+
+def test_resolve_public_ip_refuses_private(monkeypatch):
+    monkeypatch.setattr(
+        sources.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(2, 1, 6, "", ("10.0.0.5", 443))],
+    )
+    with pytest.raises(SourceSecurityError, match="non-public"):
+        sources._resolve_public_ip("evil.example")
+
+
+def test_resolve_public_ip_returns_public(monkeypatch):
+    monkeypatch.setattr(
+        sources.socket,
+        "getaddrinfo",
+        lambda *a, **k: [(2, 1, 6, "", ("10.0.0.5", 443)), (2, 1, 6, "", ("8.8.8.8", 443))],
+    )
+    assert sources._resolve_public_ip("ok.example") == "8.8.8.8"
+
+
+# --- redirect loop: auth strip + scheme/ip refusal -------------------------
+
+
+class _FakeResp:
+    def __init__(self, status, location=None, body=b""):
+        self.status = status
+        self._location = location
+        self._chunks = [body, b""] if body else [b""]
+
+    def getheader(self, key):
+        return self._location if key == "Location" else None
+
+    def read(self, n=-1):
+        return self._chunks.pop(0) if self._chunks else b""
+
+
+class _FakeConn:
+    calls: list["_FakeConn"] = []
+    responses: list[_FakeResp] = []
+
+    def __init__(self, host, pinned_ip, port=443, timeout=None):
+        self.host = host
+        self.context = None
+        self.sent_headers = None
+        _FakeConn.calls.append(self)
+        self._resp = _FakeConn.responses.pop(0)
+
+    def request(self, method, target, headers):
+        self.sent_headers = dict(headers)
+
+    def getresponse(self):
+        return self._resp
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def fake_https(monkeypatch):
+    monkeypatch.setattr(sources, "_resolve_public_ip", lambda host: "8.8.8.8")
+    monkeypatch.setattr(sources, "_PinnedHTTPSConnection", _FakeConn)
+    _FakeConn.calls = []
+    _FakeConn.responses = []
+    return _FakeConn
+
+
+def test_authorization_stripped_on_cross_host_redirect(fake_https):
+    fake_https.responses = [
+        _FakeResp(302, location="https://objects.example.com/asset"),
+        _FakeResp(200, body=b"PAYLOAD"),
+    ]
+    sink = io.BytesIO()
+    sha = sources._http_request(
+        "https://api.github.com/repos/o/r/releases/assets/9",
+        {"Authorization": "Bearer SECRET", "Accept": "application/octet-stream"},
+        sink,
+        1 << 20,
+    )
+    assert sink.getvalue() == b"PAYLOAD"
+    assert sha == __import__("hashlib").sha256(b"PAYLOAD").hexdigest()
+    assert fake_https.calls[0].host == "api.github.com"
+    assert fake_https.calls[0].sent_headers["Authorization"] == "Bearer SECRET"
+    assert "Authorization" not in fake_https.calls[1].sent_headers  # leaked? no.
+
+
+def test_authorization_kept_on_same_host_redirect(fake_https):
+    fake_https.responses = [
+        _FakeResp(302, location="https://api.github.com/second"),
+        _FakeResp(200, body=b"X"),
+    ]
+    sources._http_request(
+        "https://api.github.com/first", {"Authorization": "Bearer SECRET"}, io.BytesIO(), 1 << 20
+    )
+    assert fake_https.calls[1].sent_headers["Authorization"] == "Bearer SECRET"
+
+
+def test_non_https_refused():
+    with pytest.raises(SourceSecurityError, match="non-https"):
+        sources._http_request("http://x.example/a", {}, io.BytesIO(), 1 << 20)
+
+
+def test_ip_literal_url_refused():
+    with pytest.raises(SourceSecurityError, match="IP-literal"):
+        sources._http_request("https://93.184.216.34/a", {}, io.BytesIO(), 1 << 20)
+
+
+def test_too_many_redirects(fake_https):
+    fake_https.responses = [
+        _FakeResp(302, location=f"https://api.github.com/{i}")
+        for i in range(sources.MAX_REDIRECTS + 1)
+    ]
+    with pytest.raises(SourceFetchError, match="too many redirects"):
+        sources._http_request("https://api.github.com/0", {}, io.BytesIO(), 1 << 20)
+
+
+def test_download_size_cap(fake_https):
+    fake_https.responses = [_FakeResp(200, body=b"X" * 100)]
+    with pytest.raises(SourceSecurityError, match="exceeds"):
+        sources._http_request("https://api.github.com/big", {}, io.BytesIO(), 10)
+
+
+# --- zip extraction guards -------------------------------------------------
+
+
+def _zip(path: Path, entries: list[tuple[str, bytes]], *, symlink: str | None = None) -> Path:
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in entries:
+            zf.writestr(name, data)
+        if symlink is not None:
+            info = zipfile.ZipInfo(symlink)
+            info.external_attr = 0o120777 << 16  # S_IFLNK
+            zf.writestr(info, "target")
+    return path
+
+
+def test_zip_happy_extract(tmp_path: Path):
+    arc = _zip(tmp_path / "a.zip", [("dir/f.txt", b"hi"), ("g.bin", b"\x00\x01")])
+    out = tmp_path / "out"
+    out.mkdir()
+    sources._extract_zip(arc, out)
+    assert (out / "dir" / "f.txt").read_bytes() == b"hi"
+    assert (out / "g.bin").read_bytes() == b"\x00\x01"
+    assert (out / "dir" / "f.txt").stat().st_mode & 0o777 == 0o644
+
+
+def test_zip_rejects_traversal(tmp_path: Path):
+    arc = _zip(tmp_path / "a.zip", [("../evil", b"x")])
+    out = tmp_path / "out"
+    out.mkdir()
+    with pytest.raises(SourceSecurityError, match="unsafe archive entry"):
+        sources._extract_zip(arc, out)
+
+
+def test_zip_rejects_absolute(tmp_path: Path):
+    arc = _zip(tmp_path / "a.zip", [("/etc/passwd", b"x")])
+    out = tmp_path / "out"
+    out.mkdir()
+    with pytest.raises(SourceSecurityError, match="unsafe archive entry"):
+        sources._extract_zip(arc, out)
+
+
+def test_zip_rejects_symlink(tmp_path: Path):
+    arc = _zip(tmp_path / "a.zip", [("ok.txt", b"x")], symlink="link")
+    out = tmp_path / "out"
+    out.mkdir()
+    with pytest.raises(SourceSecurityError, match="symlink entry rejected"):
+        sources._extract_zip(arc, out)
+
+
+def test_zip_total_limit(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(sources, "MAX_TOTAL_UNCOMPRESSED", 5)
+    arc = _zip(tmp_path / "a.zip", [("a", b"123"), ("b", b"456")])
+    out = tmp_path / "out"
+    out.mkdir()
+    with pytest.raises(SourceSecurityError, match="total uncompressed"):
+        sources._extract_zip(arc, out)
+
+
+# --- tar.gz extraction guards ----------------------------------------------
+
+
+def _targz(
+    path: Path, files: list[tuple[str, bytes]], *, link: tuple[str, str] | None = None
+) -> Path:
+    with tarfile.open(path, "w:gz") as tf:
+        for name, data in files:
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+        if link is not None:
+            name, target = link
+            info = tarfile.TarInfo(name)
+            info.type = tarfile.SYMTYPE
+            info.linkname = target
+            tf.addfile(info)
+    return path
+
+
+def test_targz_happy_extract(tmp_path: Path):
+    arc = _targz(tmp_path / "a.tgz", [("pofix/.tool-versions", b"terraform 1.9.0\n")])
+    out = tmp_path / "out"
+    out.mkdir()
+    sources._extract_targz(arc, out)
+    assert (out / "pofix" / ".tool-versions").read_bytes() == b"terraform 1.9.0\n"
+
+
+def test_targz_rejects_traversal(tmp_path: Path):
+    arc = _targz(tmp_path / "a.tgz", [("../evil", b"x")])
+    out = tmp_path / "out"
+    out.mkdir()
+    with pytest.raises(SourceSecurityError, match="unsafe archive entry"):
+        sources._extract_targz(arc, out)
+
+
+def test_targz_rejects_symlink(tmp_path: Path):
+    arc = _targz(tmp_path / "a.tgz", [("ok", b"x")], link=("link", "/etc/passwd"))
+    out = tmp_path / "out"
+    out.mkdir()
+    with pytest.raises(SourceSecurityError, match="link entry rejected"):
+        sources._extract_targz(arc, out)
+
+
+def test_targz_bomb_limit(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(sources, "MAX_TOTAL_UNCOMPRESSED", 8)
+    arc = _targz(tmp_path / "a.tgz", [("big", b"X" * 64)])
+    out = tmp_path / "out"
+    out.mkdir()
+    with pytest.raises(SourceSecurityError, match="tar bomb"):
+        sources._extract_targz(arc, out)
+
+
+def test_safe_join_escape(tmp_path: Path):
+    with pytest.raises(SourceSecurityError, match="escapes destination"):
+        sources._safe_join(tmp_path, "../outside")
+
+
+# --- cache + verify --------------------------------------------------------
+
+
+def test_fetch_verified_cache_hit_no_network(tmp_path: Path, monkeypatch):
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    payload = b"cached-bytes"
+    sha = __import__("hashlib").sha256(payload).hexdigest()
+    (cache / f"{sha}.bin").write_bytes(payload)
+    src = Source(name="x", type="https", sha256=sha, extract="none", dest="x", url="https://e/a")
+
+    def _boom(*a, **k):
+        raise AssertionError("network must not be touched on a verified cache hit")
+
+    monkeypatch.setattr(sources, "_http_request", _boom)
+    got = sources._fetch_verified(src, cache, None, tmp_path)
+    assert got.read_bytes() == payload
+
+
+def test_fetch_verified_sha_mismatch_raises(tmp_path: Path, monkeypatch):
+    cache = tmp_path / "cache"
+
+    def _fake_download(url, headers, sink, max_bytes):
+        sink.write(b"unexpected")
+        return "f" * 64  # not the pinned sha
+
+    monkeypatch.setattr(sources, "_http_request", _fake_download)
+    src = Source(
+        name="x", type="https", sha256=SHA_PLACEHOLDER, extract="none", dest="x", url="https://e/a"
+    )
+    with pytest.raises(SourceSecurityError, match="sha256 mismatch"):
+        sources._fetch_verified(src, cache, None, tmp_path)
+
+
+def test_github_source_requires_token(tmp_path: Path):
+    src = Source(
+        name="p",
+        type="github_release",
+        sha256=SHA_PLACEHOLDER,
+        extract="tar.gz",
+        dest="p",
+        repo="o/r",
+        tag="t",
+        asset="a.tgz",
+    )
+    with pytest.raises(SourceFetchError, match="no token provided"):
+        sources._github_asset_url(src, None)
+
+
+# --- staging + end-to-end (no network) -------------------------------------
+
+
+def test_fetch_sources_stages_dir_member_and_file_member(tmp_path: Path, monkeypatch):
+    # Real shape: pofix tarball has a versioned top dir; a dir-member maps it to dest.
+    # terraform zip has the bare binary at root; a file-member maps it to dest.
+    tgz = _targz(
+        tmp_path / "pofix.tgz",
+        [("pofix-9.9/data/x.json", b"{}"), ("pofix-9.9/.tool-versions", b"v")],
+    )
+    zp = _zip(tmp_path / "tf.zip", [("terraform", b"BINARY")])
+    fixtures = {"pofix": tgz, "tf": zp}
+    monkeypatch.setattr(sources, "_fetch_verified", lambda src, c, t, tmp: fixtures[src.name])
+
+    srcs = (
+        Source(
+            name="pofix",
+            type="https",
+            sha256=SHA_PLACEHOLDER,
+            extract="tar.gz",
+            member="pofix-{version}",
+            dest="pofix",
+            version="9.9",
+            url="https://e/p",
+            version_from=None,
+        ),
+        Source(
+            name="tf",
+            type="https",
+            sha256="b" * 64,
+            extract="zip",
+            member="terraform",
+            dest="bin/terraform",
+            executable=True,
+            url="https://e/t",
+        ),
+    )
+    dest = tmp_path / "pkg"
+    dest.mkdir()
+    fetch_sources(sources=srcs, dest_root=dest, cache_dir=tmp_path / "c", github_token=None)
+
+    assert (dest / "pofix" / "data" / "x.json").read_bytes() == b"{}"
+    assert (dest / "pofix" / ".tool-versions").read_bytes() == b"v"
+    assert (dest / "bin" / "terraform").read_bytes() == b"BINARY"
+    assert (dest / "bin" / "terraform").stat().st_mode & 0o111  # +x
+
+
+def test_fetch_sources_whole_tree_no_member(tmp_path: Path, monkeypatch):
+    tgz = _targz(tmp_path / "t.tgz", [("a/b.txt", b"x")])
+    monkeypatch.setattr(sources, "_fetch_verified", lambda src, c, t, tmp: tgz)
+    src = Source(
+        name="t",
+        type="https",
+        sha256=SHA_PLACEHOLDER,
+        extract="tar.gz",
+        dest="vendor",
+        url="https://e/t",
+    )
+    dest = tmp_path / "pkg"
+    dest.mkdir()
+    fetch_sources(sources=(src,), dest_root=dest, cache_dir=tmp_path / "c", github_token=None)
+    assert (dest / "vendor" / "a" / "b.txt").read_bytes() == b"x"
+
+
+def test_fetch_sources_collision_refused(tmp_path: Path, monkeypatch):
+    zp = _zip(tmp_path / "t.zip", [("terraform", b"X")])
+    monkeypatch.setattr(sources, "_fetch_verified", lambda src, c, t, tmp: zp)
+    dest = tmp_path / "pkg"
+    (dest / "bin").mkdir(parents=True)
+    (dest / "bin" / "terraform").write_bytes(b"already here")  # pre-existing (e.g. from source_dir)
+    src = Source(
+        name="tf",
+        type="https",
+        sha256="b" * 64,
+        extract="zip",
+        member="terraform",
+        dest="bin/terraform",
+        url="https://e/t",
+    )
+    with pytest.raises(SourceFetchError, match="collides"):
+        fetch_sources(sources=(src,), dest_root=dest, cache_dir=tmp_path / "c", github_token=None)
+
+
+def test_fetch_sources_requires_locked_sha(tmp_path: Path):
+    src = Source(name="x", type="https", sha256="", extract="none", dest="x", url="https://e/a")
+    with pytest.raises(SourceFetchError, match="run `repro-lambda lock`"):
+        fetch_sources(
+            sources=(src,), dest_root=tmp_path, cache_dir=tmp_path / "c", github_token=None
+        )

--- a/tests/test_sources_hash.py
+++ b/tests/test_sources_hash.py
@@ -1,0 +1,109 @@
+"""compute_content_hash folds RESOLVED source metadata, download-free + deterministic."""
+
+from pathlib import Path
+
+from repro_lambda.hasher import compute_content_hash
+from repro_lambda.manifest import LambdaSpec, Source, VersionFrom
+
+PINNED = "public.ecr.aws/lambda/python:3.13@sha256:" + "0" * 64
+
+
+def _spec() -> LambdaSpec:
+    return LambdaSpec(
+        logical_name="app",
+        source_dir="handler",
+        requirements_lock="handler/requirements.${arch}.lock",
+        runtime="python3.13",
+        arch="arm64",
+        handler="app.lambda_handler",
+    )
+
+
+def _tree(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / "source"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "app.py").write_text("x = 1\n")
+    lock = tmp_path / "req.lock"
+    lock.write_text("")
+    return root, lock
+
+
+def _hash(tmp_path: Path, sources) -> str:
+    root, lock = _tree(tmp_path)
+    return compute_content_hash(
+        staged_source_root=root,
+        requirements_lock=lock,
+        spec=_spec(),
+        base_image=PINNED,
+        builder_version="0.5.0",
+        sources=sources,
+    )
+
+
+def _src(**kw) -> Source:
+    base = dict(
+        name="tf", type="https", sha256="a" * 64, extract="zip", dest="bin/tf", url="https://e/a"
+    )
+    base.update(kw)
+    return Source(**base)
+
+
+def test_none_equals_empty_and_omits_section(tmp_path):
+    assert _hash(tmp_path, None) == _hash(tmp_path, ())
+
+
+def test_adding_a_source_rekeys(tmp_path):
+    assert _hash(tmp_path, None) != _hash(tmp_path, (_src(),))
+
+
+def test_member_change_rekeys(tmp_path):
+    a = _hash(tmp_path, (_src(member="terraform"),))
+    b = _hash(tmp_path, (_src(member="tofu"),))
+    assert a != b
+
+
+def test_extract_change_rekeys(tmp_path):
+    assert _hash(tmp_path, (_src(extract="zip"),)) != _hash(tmp_path, (_src(extract="tar.gz"),))
+
+
+def test_sha256_change_rekeys(tmp_path):
+    assert _hash(tmp_path, (_src(sha256="a" * 64),)) != _hash(tmp_path, (_src(sha256="b" * 64),))
+
+
+def test_dest_change_rekeys(tmp_path):
+    assert _hash(tmp_path, (_src(dest="bin/a"),)) != _hash(tmp_path, (_src(dest="bin/b"),))
+
+
+def test_executable_change_rekeys(tmp_path):
+    assert _hash(tmp_path, (_src(executable=False),)) != _hash(tmp_path, (_src(executable=True),))
+
+
+def test_order_independent(tmp_path):
+    a = _src(name="a", dest="bin/a")
+    b = _src(name="b", dest="bin/b")
+    assert _hash(tmp_path, (a, b)) == _hash(tmp_path, (b, a))
+
+
+def test_version_from_not_hashed(tmp_path):
+    # Same resolved metadata; only the (lock-input) version_from rule differs -> same key.
+    with_rule = _src(
+        version="1.0",
+        url="https://e/{version}",
+        member="x",
+        version_from=VersionFrom(source="pofix", file=".tool-versions", key="tf"),
+    )
+    without = _src(version="1.0", url="https://e/{version}", member="x", version_from=None)
+    assert _hash(tmp_path, (with_rule,)) == _hash(tmp_path, (without,))
+
+
+def test_resolved_version_substitution_is_what_hashes(tmp_path):
+    # A {version} template + version == a concrete URL with no template.
+    templated = _src(url="https://e/{version}/tf.zip", version="1.0")
+    concrete = _src(url="https://e/1.0/tf.zip", version="")
+    assert _hash(tmp_path, (templated,)) == _hash(tmp_path, (concrete,))
+
+
+def test_different_version_rekeys(tmp_path):
+    a = _src(url="https://e/{version}/tf.zip", version="1.0")
+    b = _src(url="https://e/{version}/tf.zip", version="2.0")
+    assert _hash(tmp_path, (a,)) != _hash(tmp_path, (b,))

--- a/tests/test_sources_schema.py
+++ b/tests/test_sources_schema.py
@@ -1,0 +1,246 @@
+"""Schema parse + validation for [[lambda.source]] (declarative sources DSL)."""
+
+from pathlib import Path
+
+import pytest
+
+from repro_lambda.manifest import Source, VersionFrom, load_manifest
+
+PINNED_IMAGE = "public.ecr.aws/lambda/python:3.13@sha256:" + "0" * 64
+SHA = "a" * 64
+SHA2 = "b" * 64
+
+
+def _manifest(tmp_path: Path, sources_toml: str) -> Path:
+    p = tmp_path / "lambdas.toml"
+    p.write_text(
+        "[[lambda]]\n"
+        'logical_name      = "app"\n'
+        'source_dir        = "handler"\n'
+        'requirements_lock = "handler/requirements.${arch}.lock"\n'
+        'runtime           = "python3.13"\n'
+        'arch              = "arm64"\n'
+        'handler           = "app.lambda_handler"\n'
+        f"{sources_toml}"
+        "\n[builder]\n"
+        f'base_image_python = "{PINNED_IMAGE}"\n'
+    )
+    return p
+
+
+def _load(tmp_path: Path, sources_toml: str) -> tuple[Source, ...]:
+    return load_manifest(_manifest(tmp_path, sources_toml)).lambdas[0].sources
+
+
+# --- happy path ------------------------------------------------------------
+
+
+def test_parse_https_source(tmp_path: Path):
+    sources = _load(
+        tmp_path,
+        "[[lambda.source]]\n"
+        'name    = "tf"\n'
+        'type    = "https"\n'
+        'url     = "https://releases.example.com/tf_1.0_linux_arm64.zip"\n'
+        f'sha256  = "{SHA}"\n'
+        'extract = "zip"\n'
+        'member  = "terraform"\n'
+        'dest    = "bin/terraform"\n'
+        "executable = true\n",
+    )
+    assert sources == (
+        Source(
+            name="tf",
+            type="https",
+            sha256=SHA,
+            extract="zip",
+            dest="bin/terraform",
+            url="https://releases.example.com/tf_1.0_linux_arm64.zip",
+            member="terraform",
+            executable=True,
+        ),
+    )
+
+
+def test_parse_github_release_source(tmp_path: Path):
+    sources = _load(
+        tmp_path,
+        "[[lambda.source]]\n"
+        'name    = "pofix"\n'
+        'type    = "github_release"\n'
+        'repo    = "owner/pofix"\n'
+        'tag     = "pofix-v0.10.0"\n'
+        'asset   = "pofix-0.10.0-lambda.tar.gz"\n'
+        f'sha256  = "{SHA}"\n'
+        'extract = "tar.gz"\n'
+        'dest    = "pofix"\n',
+    )
+    s = sources[0]
+    assert s.type == "github_release"
+    assert s.repo == "owner/pofix"
+    assert s.member is None and s.executable is False
+
+
+def test_parse_version_from_and_substitution(tmp_path: Path):
+    sources = _load(
+        tmp_path,
+        "[[lambda.source]]\n"
+        'name="pofix"\ntype="github_release"\nrepo="o/pofix"\ntag="pofix-v0.10.0"\n'
+        f'asset="pofix-0.10.0.tar.gz"\nsha256="{SHA}"\nextract="tar.gz"\ndest="pofix"\n'
+        "[[lambda.source]]\n"
+        'name="tf"\ntype="https"\n'
+        'url="https://releases.example.com/terraform_{version}_linux_arm64.zip"\n'
+        f'sha256="{SHA2}"\nextract="zip"\nmember="terraform"\ndest="bin/terraform"\n'
+        'version="1.9.0"\n'
+        '[lambda.source.version_from]\nsource="pofix"\nfile=".tool-versions"\nkey="terraform"\n',
+    )
+    tf = sources[1]
+    assert tf.version_from == VersionFrom(source="pofix", file=".tool-versions", key="terraform")
+    assert tf.resolved_url == "https://releases.example.com/terraform_1.9.0_linux_arm64.zip"
+
+
+def test_sources_default_empty(tmp_path: Path):
+    assert _load(tmp_path, "") == ()
+
+
+def test_sha256_may_be_empty_pre_lock(tmp_path: Path):
+    sources = _load(
+        tmp_path,
+        '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/a.zip"\n'
+        'sha256=""\nextract="none"\ndest="x"\n',
+    )
+    assert sources[0].sha256 == ""
+
+
+# --- validation: rejects ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("toml", "match"),
+    [
+        (
+            '[[lambda.source]]\ntype="https"\nurl="https://e.com/a"\nextract="none"\ndest="x"\n',
+            "non-empty 'name'",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="ftp"\nurl="https://e.com/a"\nextract="none"\ndest="x"\n',
+            "type must be one of",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/a"\nextract="rar"\ndest="x"\n',
+            "extract must be one of",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/a"\nextract="none"\ndest=""\n',
+            "non-empty 'dest'",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/a"\nextract="none"\ndest="/abs"\n',
+            "without '..'",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/a"\nextract="none"\ndest="../up"\n',
+            "without '..'",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/a"\nsha256="nothex"\nextract="none"\ndest="x"\n',
+            "64 lowercase hex",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/a"\nextract="none"\nmember="m"\ndest="x"\n',
+            "extract='none'",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="github_release"\ntag="t"\nasset="a"\nextract="none"\ndest="x"\n',
+            "requires non-empty 'repo'",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="github_release"\nrepo="bad"\ntag="t"\nasset="a"\nextract="none"\ndest="x"\n',
+            "must be 'owner/name'",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="github_release"\nrepo="o/r"\ntag="t"\nasset="a"\nurl="https://e.com/a"\nextract="none"\ndest="x"\n',
+            "must not set 'url'",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="https"\nextract="none"\ndest="x"\n',
+            "requires non-empty 'url'",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="https"\nurl="http://e.com/a"\nextract="none"\ndest="x"\n',
+            "must start with https://",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/a"\nrepo="o/r"\nextract="none"\ndest="x"\n',
+            "must not set 'repo'",
+        ),
+        (
+            '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/{version}"\nextract="none"\ndest="x"\n',
+            "no 'version' value or",
+        ),
+    ],
+)
+def test_rejects_invalid_source(tmp_path: Path, toml: str, match: str):
+    with pytest.raises(ValueError, match=match):
+        _load(tmp_path, toml)
+
+
+def test_rejects_duplicate_name(tmp_path: Path):
+    toml = (
+        '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/a"\nextract="none"\ndest="a"\n'
+        '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/b"\nextract="none"\ndest="b"\n'
+    )
+    with pytest.raises(ValueError, match="duplicate source name"):
+        _load(tmp_path, toml)
+
+
+def test_rejects_version_from_self_reference(tmp_path: Path):
+    toml = (
+        '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/{version}"\n'
+        'extract="none"\ndest="a"\n'
+        '[lambda.source.version_from]\nsource="x"\nfile="f"\nkey="k"\n'
+    )
+    with pytest.raises(ValueError, match="cannot reference itself"):
+        _load(tmp_path, toml)
+
+
+def test_rejects_version_from_unknown_source(tmp_path: Path):
+    toml = (
+        '[[lambda.source]]\nname="x"\ntype="https"\nurl="https://e.com/{version}"\n'
+        'extract="none"\ndest="a"\n'
+        '[lambda.source.version_from]\nsource="ghost"\nfile="f"\nkey="k"\n'
+    )
+    with pytest.raises(ValueError, match="not a defined source"):
+        _load(tmp_path, toml)
+
+
+def test_rejects_two_level_version_from(tmp_path: Path):
+    toml = (
+        '[[lambda.source]]\nname="a"\ntype="https"\nurl="https://e.com/{version}"\n'
+        'extract="none"\ndest="a"\n'
+        '[lambda.source.version_from]\nsource="b"\nfile="f"\nkey="k"\n'
+        '[[lambda.source]]\nname="b"\ntype="https"\nurl="https://e.com/{version}"\n'
+        'extract="none"\ndest="b"\n'
+        '[lambda.source.version_from]\nsource="c"\nfile="f"\nkey="k"\n'
+        '[[lambda.source]]\nname="c"\ntype="https"\nurl="https://e.com/x"\n'
+        'extract="none"\ndest="c"\n'
+    )
+    with pytest.raises(ValueError, match="single-level only"):
+        _load(tmp_path, toml)
+
+
+def test_rejects_dest_tree_overlap(tmp_path: Path):
+    toml = (
+        '[[lambda.source]]\nname="a"\ntype="https"\nurl="https://e.com/a"\nextract="none"\ndest="bin"\n'
+        '[[lambda.source]]\nname="b"\ntype="https"\nurl="https://e.com/b"\nextract="none"\ndest="bin/tf"\n'
+    )
+    with pytest.raises(ValueError, match="dest overlap"):
+        _load(tmp_path, toml)
+
+
+def test_allows_sibling_dests(tmp_path: Path):
+    toml = (
+        '[[lambda.source]]\nname="a"\ntype="https"\nurl="https://e.com/a"\nextract="none"\ndest="bin/a"\n'
+        '[[lambda.source]]\nname="b"\ntype="https"\nurl="https://e.com/b"\nextract="none"\ndest="bin/b"\n'
+    )
+    assert len(_load(tmp_path, toml)) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -646,11 +646,12 @@ wheels = [
 
 [[package]]
 name = "repro-lambda"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "repro-zipfile" },
+    { name = "tomlkit" },
     { name = "typer" },
 ]
 
@@ -674,6 +675,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6" },
     { name = "repro-zipfile", specifier = ">=0.3.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
+    { name = "tomlkit", specifier = ">=0.13" },
     { name = "typer", specifier = ">=0.12" },
 ]
 provides-extras = ["dev"]
@@ -782,6 +784,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds `[[lambda.source]]` - pinned external artifacts (`github_release` | `https`) fetched, sha256-verified, and extracted into the package **before** the container build. This replaces consumer-side download/bump bash scripts with one declarative, hardened, content-addressed mechanism.

## Why

Consumers currently materialize prebuilt trees + vendored CLIs with bespoke shell (download, sha-pin, extract, bump). That logic belongs in the tool, behind a pinned + reproducible contract, with the security hardening done once.

## Highlights

- **Schema** (`manifest.py`): unique-named sources; `extract` zip/tar.gz/none; `member` selects a file or a (versioned) directory subtree to a package-relative `dest`; `{version}` templating; **single-level `version_from`** (derive a source's version from another source's asdf-style file at lock time); dest-collision + path validation.
- **`sources.py`** (new): SSRF-hardened fetcher - HTTPS-only manual redirect loop, per-hop **pinned-IP connect with cert-vs-hostname** (DNS-rebind safe), reject non-global/reserved/metadata IPs, **strip `Authorization` on cross-host redirect**, size cap, redacted logs. **Verify-before-extract**; reject absolute/`..`/symlink/hardlink/device entries; total/entry/per-entry **bomb bounds** (streaming tar); sha256-keyed cache **re-verified on every use**.
- **`hasher.py`**: folds **resolved source metadata only** (download-free; `version_from` excluded), so `member`/`extract`/`dest`/`sha256`/version changes re-key, a re-fetch alone does not.
- **`build.py`**: fetch on **cache-miss only**, into the staged tree (post-filter, collides loudly).
- **`cli.py`**: `build` reads `REPRO_LAMBDA_SOURCES_TOKEN`; `lock` gains `--sources` (version_from resolve + sha re-pin + **idempotent** tomlkit rewrite) + `--requirements` toggles. New `source_locker.py`.
- **`build.yml`**: generic `sources_token` secret + arch-scoped `actions/cache`. Adds `tomlkit` dep. Bumps `0.4.2 -> 0.5.0`.

## Tests

191 non-docker tests green (`uv run pytest -m "not docker"`), ruff + format clean. New coverage: schema validation, SSRF reserved-range + redirect auth-strip, zip/tar-slip + bomb rejection, dest-collision, download-free hash determinism, `version_from` lock + idempotency.

## Notes

- repro-lambda is public; this PR contains zero consumer/internal names - the private repo, tool URLs, and pins live only in the consumer's `lambdas.toml`. `sources_token` is a generic input.
- Tagging `v0.5.0` (which publishes + moves `@v0`) happens after merge + review.