### PR TITLE
fix: send User-Agent on source fetches (GitHub API 403s without one) [v0.5.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.1 - 2026-06-21
+
+### Fixed
+- Send a `User-Agent` header on every source fetch. The GitHub REST API rejects requests with no User-Agent (HTTP 403), which broke `github_release` source resolution (the asset lookup against `api.github.com`). The header is now `repro-lambda/<version>` on all requests (harmless for plain `https` sources, required for the API). Does not affect any content hash (request headers are not part of artifact identity).
+
 ## v0.5.0 - 2026-06-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repro-lambda"
-version = "0.5.0"
+version = "0.5.1"
 description = "Build reproducible AWS Lambda packages outside Terraform, optimized for terraform-aws-lambda by serverless.tf."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/repro_lambda/__init__.py
+++ b/src/repro_lambda/__init__.py
@@ -1,3 +1,3 @@
 """repro-lambda — reproducible AWS Lambda packaging outside Terraform."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/repro_lambda/sources.py
+++ b/src/repro_lambda/sources.py
@@ -36,6 +36,7 @@ from http.client import HTTPSConnection
 from pathlib import Path
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
+from repro_lambda import __version__
 from repro_lambda.manifest import Source
 
 # Limits (decompression-bomb + DoS bounds). Generous enough for real release artifacts.
@@ -48,6 +49,9 @@ HTTP_TIMEOUT = 60  # seconds per hop
 _GITHUB_API = "https://api.github.com"
 _JSON_MAX_BYTES = 16 * 1024 * 1024
 _CHUNK = 64 * 1024
+# The GitHub REST API rejects requests with no User-Agent (HTTP 403); send one on every
+# request (harmless for the plain https sources, required for github_release resolution).
+_USER_AGENT = f"repro-lambda/{__version__}"
 
 
 class SourceFetchError(RuntimeError):
@@ -143,7 +147,11 @@ def _http_request(
         conn.context = context
         try:
             target = parts.path + (f"?{parts.query}" if parts.query else "")
-            conn.request("GET", target or "/", headers={**req_headers, "Host": host})
+            conn.request(
+                "GET",
+                target or "/",
+                headers={"User-Agent": _USER_AGENT, **req_headers, "Host": host},
+            )
             resp = conn.getresponse()
             if resp.status in (301, 302, 303, 307, 308):
                 location = resp.getheader("Location")

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -162,6 +162,13 @@ def test_authorization_kept_on_same_host_redirect(fake_https):
     assert fake_https.calls[1].sent_headers["Authorization"] == "Bearer SECRET"
 
 
+def test_user_agent_header_is_sent(fake_https):
+    # GitHub's REST API 403s requests with no User-Agent; we must always send one.
+    fake_https.responses = [_FakeResp(200, body=b"X")]
+    sources._http_request("https://api.github.com/x", {}, io.BytesIO(), 1 << 20)
+    assert fake_https.calls[0].sent_headers.get("User-Agent", "").startswith("repro-lambda/")
+
+
 def test_non_https_refused():
     with pytest.raises(SourceSecurityError, match="non-https"):
         sources._http_request("http://x.example/a", {}, io.BytesIO(), 1 << 20)

--- a/uv.lock
+++ b/uv.lock
@@ -646,7 +646,7 @@ wheels = [
 
 [[package]]
 name = "repro-lambda"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
The GitHub REST API rejects requests with no `User-Agent` (HTTP 403), which broke `github_release` source resolution against `api.github.com` - surfaced by the first real consumer build. Now sends `repro-lambda/<version>` on every request (harmless for plain https sources, required for the API). Not part of any content hash. New test asserts the header is sent. 192 non-docker tests green.