### PR TITLE
fix: pass full manylinux range to pip so compiled wheels are selected [v0.5.2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.2 - 2026-06-21
+
+### Fixed
+- Pass the full compatible manylinux range to `pip install` instead of a single `--platform`, so compiled wheels are selected for every package. A single explicit `--platform` matches (close to) that exact tag - it does not broaden across baselines - so `manylinux_2_17` silently dropped compiled wheels tagged only at a higher baseline. Concretely, `wrapt`'s cp313 wheel is tagged `manylinux_2_28` (no `2_17`), so pip fell back to the pure-Python `py3-none-any` build; that broke `aws-xray-sdk`'s runtime boto3 patching and 500'd a Lambda whose package included it. The v0.4.1 change (2_28 -> 2_17, to catch `pydantic-core`'s 2_17-only wheel) had created the opposite failure - a single floor cannot satisfy both. Now `docker_runner.py` emits repeated `--platform` flags from `manylinux_2_34` down to `manylinux1` (x86_64) / `manylinux2014` (aarch64), capped at the AL2023 runtime's glibc 2.34, and pip picks the most-specific compiled wheel each package offers, only using `py3-none-any` when no compiled wheel exists. Verified end to end: a real build now ships `wrapt/_wrappers.*.so` again. The builder version bump re-keys all content hashes, as expected.
+
 ## v0.5.1 - 2026-06-21
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repro-lambda"
-version = "0.5.1"
+version = "0.5.2"
 description = "Build reproducible AWS Lambda packages outside Terraform, optimized for terraform-aws-lambda by serverless.tf."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/repro_lambda/__init__.py
+++ b/src/repro_lambda/__init__.py
@@ -1,3 +1,3 @@
 """repro-lambda — reproducible AWS Lambda packaging outside Terraform."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/src/repro_lambda/docker_runner.py
+++ b/src/repro_lambda/docker_runner.py
@@ -12,16 +12,49 @@ ARCH_TO_DOCKER_PLATFORM: dict[str, str] = {
     "x86_64": "linux/amd64",
 }
 
-# manylinux_2_17 (== manylinux2014) is the broadest baseline the AWS Lambda base
-# images (Amazon Linux 2023, glibc 2.34) still run, and pip's explicit --platform does
-# NOT expand a higher tag (e.g. 2_28) down to lower-baseline wheels. Many compiled
-# wheels (e.g. pydantic-core) ship only manylinux_2_17 for a given Python/arch, so a
-# 2_28 floor misses them with --only-binary=:all:. 2_17 matches 2_17 wheels and, via
-# pip's tag expansion, any lower baseline too.
-ARCH_TO_PIP_PLATFORM: dict[str, str] = {
-    "arm64": "manylinux_2_17_aarch64",
-    "x86_64": "manylinux_2_17_x86_64",
+# The AWS Lambda base images (Amazon Linux 2023) ship glibc 2.34, so the runtime can load
+# any manylinux wheel up to manylinux_2_34. pip's explicit --platform matches (close to)
+# that exact tag, so a SINGLE platform misses wheels tagged with other baselines in both
+# directions: a 2_28 floor misses 2_17-only wheels (e.g. pydantic-core), and a 2_17 floor
+# misses higher-baseline compiled wheels (e.g. wrapt ships cp313 only as manylinux_2_28 ->
+# pip silently falls back to py3-none-any, which broke aws-xray-sdk's runtime boto3 patching
+# and 500'd a Lambda). A single floor cannot satisfy both. Pass the FULL compatible range as
+# repeated --platform flags, newest -> oldest, capped at 2_34 (the runtime's glibc): pip then
+# selects the most-specific COMPILED wheel each package offers and only falls back to
+# py3-none-any when no compiled wheel exists. Never list a baseline ABOVE 2_34 - that would
+# let pip pick a wheel the runtime cannot load. (arm64 manylinux starts at 2014/2_17; the
+# manylinux1/2010/2_5 legacy aliases are x86_64-only.)
+ARCH_TO_PIP_PLATFORMS: dict[str, list[str]] = {
+    "x86_64": [
+        "manylinux_2_34_x86_64",
+        "manylinux_2_28_x86_64",
+        "manylinux_2_24_x86_64",
+        "manylinux2014_x86_64",
+        "manylinux_2_17_x86_64",
+        "manylinux_2_12_x86_64",
+        "manylinux2010_x86_64",
+        "manylinux_2_5_x86_64",
+        "manylinux1_x86_64",
+    ],
+    "arm64": [
+        "manylinux_2_34_aarch64",
+        "manylinux_2_28_aarch64",
+        "manylinux_2_24_aarch64",
+        "manylinux2014_aarch64",
+        "manylinux_2_17_aarch64",
+    ],
 }
+
+
+def pip_platform_flags(arch: str) -> str:
+    """Repeated ``--platform <tag>`` flags (space-joined) for an arch's manylinux range.
+
+    Word-split UNQUOTED into the pip command in the container so each tag becomes its own
+    flag. pip treats a wheel as compatible with ANY listed platform and prefers the
+    earliest (newest baseline) match, so compiled wheels win over the py3-none-any fallback.
+    """
+    return " ".join(f"--platform {tag}" for tag in ARCH_TO_PIP_PLATFORMS[arch])
+
 
 ARCH_TO_NPM_CPU: dict[str, str] = {
     "arm64": "arm64",
@@ -31,9 +64,9 @@ ARCH_TO_NPM_CPU: dict[str, str] = {
 # Invariance: keys must match across all arch lookup tables. Adding a new arch
 # to one without the other would cause install_nodejs_dependencies to raise
 # KeyError instead of DockerRunError. Caught at import time.
-assert set(ARCH_TO_DOCKER_PLATFORM) == set(ARCH_TO_PIP_PLATFORM) == set(ARCH_TO_NPM_CPU), (
+assert set(ARCH_TO_DOCKER_PLATFORM) == set(ARCH_TO_PIP_PLATFORMS) == set(ARCH_TO_NPM_CPU), (
     "arch lookup tables must share the same key set; "
-    f"DOCKER={set(ARCH_TO_DOCKER_PLATFORM)} PIP={set(ARCH_TO_PIP_PLATFORM)} NPM={set(ARCH_TO_NPM_CPU)}"
+    f"DOCKER={set(ARCH_TO_DOCKER_PLATFORM)} PIP={set(ARCH_TO_PIP_PLATFORMS)} NPM={set(ARCH_TO_NPM_CPU)}"
 )
 
 
@@ -49,7 +82,7 @@ cp -R /src/source/. "$PKG/"
 
 pip install \
   --no-cache-dir --no-compile --require-hashes --only-binary=:all: \
-  --platform "$PIP_PLATFORM" \
+  $PIP_PLATFORM_FLAGS \
   --abi "$PIP_ABI" \
   --python-version "$PIP_PYVER" \
   --implementation cp \
@@ -130,7 +163,7 @@ def build_python_lambda(
     python_version: str,
 ) -> None:
     """v0.1-compatible: install + pack inside the Python container."""
-    if arch not in ARCH_TO_PIP_PLATFORM:
+    if arch not in ARCH_TO_PIP_PLATFORMS:
         raise DockerRunError(f"unsupported arch {arch!r}")
     if shutil.which("docker") is None:
         raise DockerRunError("docker CLI not found on PATH")
@@ -158,7 +191,7 @@ def build_python_lambda(
         "-e",
         "PYTHONPATH=/builder",
         "-e",
-        f"PIP_PLATFORM={ARCH_TO_PIP_PLATFORM[arch]}",
+        f"PIP_PLATFORM_FLAGS={pip_platform_flags(arch)}",
         "-e",
         f"PIP_ABI=cp{pyver_compact}",
         "-e",

--- a/tests/test_docker_runner.py
+++ b/tests/test_docker_runner.py
@@ -5,23 +5,39 @@ import pytest
 
 from repro_lambda.docker_runner import (
     ARCH_TO_DOCKER_PLATFORM,
-    ARCH_TO_PIP_PLATFORM,
+    ARCH_TO_PIP_PLATFORMS,
     DockerRunError,
     build_python_lambda,
+    pip_platform_flags,
 )
 
 
 def test_arch_mapping_tables_are_complete():
     for arch in ("arm64", "x86_64"):
         assert arch in ARCH_TO_DOCKER_PLATFORM
-        assert arch in ARCH_TO_PIP_PLATFORM
+        assert arch in ARCH_TO_PIP_PLATFORMS
 
 
 def test_arch_mapping_values():
     assert ARCH_TO_DOCKER_PLATFORM["arm64"] == "linux/arm64"
     assert ARCH_TO_DOCKER_PLATFORM["x86_64"] == "linux/amd64"
-    assert ARCH_TO_PIP_PLATFORM["arm64"] == "manylinux_2_17_aarch64"
-    assert ARCH_TO_PIP_PLATFORM["x86_64"] == "manylinux_2_17_x86_64"
+
+
+def test_pip_platform_flags_span_the_range_and_cap_at_2_34():
+    """Multiple --platform flags so pip picks the best COMPILED wheel per package; a single
+    tag silently dropped compiled wheels (e.g. wrapt -> py3-none-any). Cap at glibc 2.34."""
+    for arch, tag_arch in (("x86_64", "x86_64"), ("arm64", "aarch64")):
+        flags = pip_platform_flags(arch)
+        tags = ARCH_TO_PIP_PLATFORMS[arch]
+        # Repeated --platform, one per tag, in declared (newest-first) order.
+        assert flags == " ".join(f"--platform {t}" for t in tags)
+        assert flags.count("--platform ") == len(tags)
+        # Must include both the historical floors that each broke one direction.
+        assert f"manylinux_2_17_{tag_arch}" in flags  # pydantic-core (2_17-only) still resolves
+        assert f"manylinux_2_28_{tag_arch}" in flags  # wrapt's compiled cp313 wheel resolves
+        # Never a baseline above the runtime's glibc 2.34 (would be unloadable).
+        for n in (35, 36, 38, 40):
+            assert f"manylinux_2_{n}_" not in flags
 
 
 def test_build_python_lambda_raises_on_unknown_arch(tmp_path: Path):

--- a/uv.lock
+++ b/uv.lock
@@ -646,7 +646,7 @@ wheels = [
 
 [[package]]
 name = "repro-lambda"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Incident
A real dev webhook 500'd after the v0.5.1 cut-over. Root cause: `verify_webhook`'s package shipped a **pure-Python `wrapt`** (`py3-none-any`) instead of the compiled wheel, which broke `aws-xray-sdk`'s runtime boto3 patching. Confirmed by diffing the deployed artifacts - the only file difference was the dropped `wrapt/_wrappers.cpython-313-x86_64-linux-gnu.so`.

## Root cause
A single explicit `--platform` matches ~that exact tag and does **not** broaden across manylinux baselines. `wrapt`'s cp313 wheel is tagged `manylinux_2_28` (no `2_17`), so `--platform manylinux_2_17` rejected it and fell back to pure-Python. The v0.4.1 change (2_28 -> 2_17, to catch `pydantic-core`'s 2_17-only wheel) created the opposite miss. **A single floor cannot satisfy both.**

## Fix
`docker_runner.py` now passes the full compatible range as repeated `--platform` flags (`manylinux_2_34` down to `manylinux1` / `manylinux2014` for aarch64), capped at the AL2023 runtime's glibc 2.34. pip picks the most-specific **compiled** wheel each package offers, using `py3-none-any` only when no compiled wheel exists.

## Verification
- `pip download wrapt==2.2.1` with the new flags -> selects the **compiled** `manylinux_2_28` wheel (was `py3-none-any`).
- A real build of verify_webhook's `requirements.x86_64.lock` in the Lambda python3.13 image now ships `wrapt/_wrappers.*.so`.
- 193 non-docker tests green; new unit test asserts the multi-platform flag set spans 2_17+2_28 and never exceeds 2_34.

Bumps 0.5.1 -> 0.5.2 (re-keys all content hashes, as expected). After merge+tag, the consumer rebuilds all 4 lambdas under v0.5.2 and infra re-pins.