### PR TITLE
feat: promote by explicit content sha + build Step Summary [v0.6.0]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,27 @@ on:
         required: false
         default: ""
         description: S3 bucket name for prod Lambda artifacts (master push only).
+      promotion_repo:
+        type: string
+        required: false
+        default: ""
+        description: >-
+          owner/repo of the centralized promotion workflow. When set, the build Step
+          Summary renders a ready-to-run `gh workflow run` command per function. Generic
+          by design - the reusable workflow never hardcodes a promotion target; the caller
+          supplies it (keep this empty for public callers).
+      promotion_workflow:
+        type: string
+        required: false
+        default: promote-lambda.yml
+        description: Workflow file name dispatched by the promotion command in the Step Summary.
+      project:
+        type: string
+        required: false
+        default: ""
+        description: >-
+          Project key the promotion workflow expects (-f project=...). Defaults to the
+          caller repo name when empty.
     secrets:
       sources_token:
         required: false
@@ -92,7 +113,60 @@ jobs:
         env:
           REPRO_LAMBDA_BUCKET: ${{ inputs.dev_bucket }}
           REPRO_LAMBDA_SOURCES_TOKEN: ${{ secrets.sources_token }}
-        run: uvx --from repro-lambda repro-lambda build --manifest "${{ inputs.manifest_path }}" --arch "${{ matrix.arch }}"
+        run: uvx --from repro-lambda repro-lambda build --manifest "${{ inputs.manifest_path }}" --arch "${{ matrix.arch }}" --json-out "$RUNNER_TEMP/build-summary.json"
+
+      # Render the dev build's content shas + a copy-paste promotion command per function
+      # into the run's Step Summary (the build JSON is otherwise buried in step logs).
+      - name: Build summary (content shas + promote commands)
+        if: ${{ hashFiles(format('{0}/build-summary.json', runner.temp)) != '' }}
+        env:
+          SUMMARY_JSON: ${{ runner.temp }}/build-summary.json
+          PROMOTION_REPO: ${{ inputs.promotion_repo }}
+          PROMOTION_WORKFLOW: ${{ inputs.promotion_workflow }}
+          PROJECT: ${{ inputs.project != '' && inputs.project || github.event.repository.name }}
+          ARCH: ${{ matrix.arch }}
+          SRC_REPO: ${{ github.repository }}
+          SRC_COMMIT: ${{ github.sha }}
+        run: |
+          python3 - <<'PY'
+          import json, os
+
+          rows = json.load(open(os.environ["SUMMARY_JSON"]))
+          repo = os.environ["PROMOTION_REPO"]
+          wf = os.environ["PROMOTION_WORKFLOW"]
+          project = os.environ["PROJECT"]
+          arch = os.environ["ARCH"]
+          src = os.environ["SRC_REPO"]
+          commit = os.environ["SRC_COMMIT"]
+
+          out = [
+              f"## Lambda build ({arch})",
+              "",
+              f"Source: `{src}` @ `{commit[:12]}`",
+              "",
+              "| Function | Outcome | Content SHA | Dev key |",
+              "| --- | --- | --- | --- |",
+          ]
+          for r in rows:
+              out.append(
+                  f"| `{r['logical_name']}` | {r['outcome']} | `{r['sha256']}` | `{r['bucket_key']}` |"
+              )
+          out += ["", "### Promote to prod", ""]
+          for r in rows:
+              fn, sha = r["logical_name"], r["sha256"]
+              out += [f"**`{fn}`** prod pin: `{fn} = \"{sha}\"`", ""]
+              if repo:
+                  out += [
+                      "```bash",
+                      f"gh workflow run {wf} --repo {repo} "
+                      f"-f project={project} -f function={fn} -f sha={sha}",
+                      "```",
+                      "",
+                  ]
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write("\n".join(out) + "\n")
+          PY
 
       - name: Verify reproducible (PR only)
         if: github.event_name == 'pull_request'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "repro-lambda"
-version = "0.5.2"
+version = "0.6.0"
 description = "Build reproducible AWS Lambda packages outside Terraform, optimized for terraform-aws-lambda by serverless.tf."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/repro_lambda/__init__.py
+++ b/src/repro_lambda/__init__.py
@@ -1,3 +1,3 @@
 """repro-lambda — reproducible AWS Lambda packaging outside Terraform."""
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"

--- a/src/repro_lambda/cli.py
+++ b/src/repro_lambda/cli.py
@@ -70,6 +70,13 @@ def build(
             "--arch", help="Only build lambdas with this arch (e.g. arm64, x86_64). Empty = all."
         ),
     ] = "",
+    json_out: Annotated[
+        Path | None,
+        typer.Option(
+            "--json-out",
+            help="Also write the build summary JSON array to this file (for CI Step Summary).",
+        ),
+    ] = None,
 ) -> None:
     """Build one lambda (or all) per manifest and upload to S3."""
     import json
@@ -170,6 +177,9 @@ def build(
     if not dry_run:
         catalog.save(catalog_path)
 
+    if json_out is not None:
+        json_out.write_text(json.dumps(summary, indent=2))
+
     typer.echo(json.dumps(summary, indent=2))
 
 
@@ -196,14 +206,25 @@ def promote(
             help="Destination (prod) base bucket; us-east-1 variant auto-derived.",
         ),
     ] = "",
+    sha: Annotated[
+        str,
+        typer.Option(
+            "--sha",
+            help="Promote this exact 64-hex content sha instead of the catalog's current. "
+            "Requires a single lambda target (not 'all').",
+        ),
+    ] = "",
     dry_run: Annotated[bool, typer.Option("--dry-run")] = False,
 ) -> None:
     """Copy built artifacts dev -> prod by content hash (no rebuild).
 
-    The sha per lambda is read from builds/catalog.json, so the artifact promoted
-    is exactly the one the source commit built and tested in dev.
+    By default the sha per lambda is read from builds/catalog.json, so the artifact
+    promoted is exactly the one the source commit built and tested in dev. Pass
+    ``--sha`` to promote one explicit content sha (e.g. copy-pasted from a build run's
+    Step Summary), bypassing the catalog.
     """
     import json
+    import re
 
     from repro_lambda.manifest import load_manifest
     from repro_lambda.promote import (
@@ -225,6 +246,14 @@ def promote(
         typer.echo(f"no lambda named {target!r} in {manifest}", err=True)
         raise typer.Exit(2)
 
+    if sha:
+        if target == "all" or len(selected) != 1:
+            typer.echo("--sha requires a single lambda target (not 'all')", err=True)
+            raise typer.Exit(2)
+        if not re.fullmatch(r"[a-f0-9]{64}", sha):
+            typer.echo(f"--sha must be 64 lowercase hex chars, got {sha!r}", err=True)
+            raise typer.Exit(2)
+
     if not dry_run and (not dev_bucket or not prod_bucket):
         typer.echo(
             "--dev-bucket and --prod-bucket (or REPRO_LAMBDA_DEV_BUCKET / "
@@ -237,10 +266,10 @@ def promote(
     summary = []
     for spec in selected:
         try:
-            sha = sha_from_catalog(catalog_path, spec.logical_name)
+            resolved_sha = sha or sha_from_catalog(catalog_path, spec.logical_name)
             outcome = promote_one(
                 spec=spec,
-                sha=sha,
+                sha=resolved_sha,
                 dev_bucket=dev_bucket,
                 prod_bucket=prod_bucket,
                 dry_run=dry_run,

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -226,3 +226,74 @@ def test_cli_promote_unknown_target_exits_2(tmp_path: Path):
         ],
     )
     assert result.exit_code == 2
+
+
+_EXPLICIT_SHA = "a" * 64  # 64-hex, deliberately NOT the catalog's "cafef00d"
+
+
+def test_cli_promote_explicit_sha_bypasses_catalog(tmp_path: Path):
+    repo = _consumer(tmp_path)
+    with mock_aws():
+        c = boto3.client("s3", region_name="eu-west-1")
+        _make_bucket(c, DEV, "eu-west-1")
+        _make_bucket(c, PROD, "eu-west-1")
+        # Only the explicit-sha object exists; the catalog's current sha does not.
+        c.put_object(Bucket=DEV, Key=f"lambdas/app/{_EXPLICIT_SHA}.zip", Body=b"z")
+
+        result = runner.invoke(
+            app,
+            [
+                "promote",
+                "app",
+                "--manifest",
+                str(repo / "lambdas.toml"),
+                "--dev-bucket",
+                DEV,
+                "--prod-bucket",
+                PROD,
+                "--sha",
+                _EXPLICIT_SHA,
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        assert c.head_object(Bucket=PROD, Key=f"lambdas/app/{_EXPLICIT_SHA}.zip")
+
+
+def test_cli_promote_sha_rejects_all_target(tmp_path: Path):
+    repo = _consumer(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "all",
+            "--manifest",
+            str(repo / "lambdas.toml"),
+            "--dev-bucket",
+            DEV,
+            "--prod-bucket",
+            PROD,
+            "--sha",
+            _EXPLICIT_SHA,
+        ],
+    )
+    assert result.exit_code == 2  # --sha forbidden with 'all'
+
+
+def test_cli_promote_sha_invalid_hex_exits_2(tmp_path: Path):
+    repo = _consumer(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "promote",
+            "app",
+            "--manifest",
+            str(repo / "lambdas.toml"),
+            "--dev-bucket",
+            DEV,
+            "--prod-bucket",
+            PROD,
+            "--sha",
+            "not-a-valid-sha",
+        ],
+    )
+    assert result.exit_code == 2  # not 64-hex

--- a/uv.lock
+++ b/uv.lock
@@ -646,7 +646,7 @@ wheels = [
 
 [[package]]
 name = "repro-lambda"
-version = "0.5.2"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## What

- `promote <fn> --sha <64hex>`: promote one explicit content sha, bypassing `builds/catalog.json`. 64-hex validated; refuses `all` (single target only). Existing catalog-driven mode unchanged.
- `build --json-out <file>`: write the build summary JSON array to a file (stdout stays the human view) so CI can render it deterministically.
- Reusable `build.yml`: render a per-run **Step Summary** - a table (function | outcome | content sha | dev key) plus, per function, the prod pin snippet and a ready-to-run `gh workflow run` promotion command.

## Public-safe by design

The reusable workflow hardcodes no promotion target. The `gh workflow run` line is built from caller-supplied inputs (`promotion_repo`, `promotion_workflow`, `project`); leave them empty for public callers and only the table + pin snippet render.

## Notes

- Bumps to **0.6.0**. `builder_version` folds into the content hash, so this re-keys artifacts on the next consumer rebuild (byte-identical zips, new keys).
- Tests: +3 covering `--sha` (explicit-sha bypass, `all` rejection, non-hex rejection). Full non-docker suite green (196).

## Test plan

- [x] `uv run pytest -m 'not docker'` (196 passed)
- [x] `uv run ruff check .`
- [x] Step Summary renderer validated against a sample build JSON