### PR TITLE
fix(ci): render build Step Summary (hashFiles cannot guard a RUNNER_TEMP file)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,10 @@ jobs:
 
       # Render the dev build's content shas + a copy-paste promotion command per function
       # into the run's Step Summary (the build JSON is otherwise buried in step logs).
+      # NB: the JSON lives in RUNNER_TEMP (outside the workspace), so hashFiles() can't guard
+      # it - run on success() and skip inside the script if the file is somehow absent.
       - name: Build summary (content shas + promote commands)
-        if: ${{ hashFiles(format('{0}/build-summary.json', runner.temp)) != '' }}
+        if: success()
         env:
           SUMMARY_JSON: ${{ runner.temp }}/build-summary.json
           PROMOTION_REPO: ${{ inputs.promotion_repo }}
@@ -129,9 +131,13 @@ jobs:
           SRC_COMMIT: ${{ github.sha }}
         run: |
           python3 - <<'PY'
-          import json, os
+          import json, os, sys
 
-          rows = json.load(open(os.environ["SUMMARY_JSON"]))
+          path = os.environ["SUMMARY_JSON"]
+          if not os.path.exists(path):
+              print(f"::notice::no build summary JSON at {path}; skipping summary.")
+              sys.exit(0)
+          rows = json.load(open(path))
           repo = os.environ["PROMOTION_REPO"]
           wf = os.environ["PROMOTION_WORKFLOW"]
           project = os.environ["PROJECT"]


### PR DESCRIPTION
## Bug

The `Build summary` step (added in 0.6.0) guarded its run with `if: hashFiles(runner.temp/build-summary.json) != ''`. But `hashFiles()` only resolves paths **inside GITHUB_WORKSPACE** - a `RUNNER_TEMP` path never matches, so the step was always **skipped** and no Step Summary rendered (confirmed on a live pofix-integration build: step conclusion `skipped`).

## Fix

Run on `success()` (the dev build always writes `--json-out` on success), with an in-script existence fallback. Workflow-only change - package version and content hashes are unchanged, so `@v0` is moved without a PyPI re-release (no artifact re-key).

## Test plan
- [x] actionlint clean
- [ ] Next build run: `Build summary` step runs (not skipped) and the summary shows the table + per-function `gh workflow run` command