### PR TITLE
feat: support the python3.14 lambda runtime

### DIFF
--- a/src/repro_lambda/manifest.py
+++ b/src/repro_lambda/manifest.py
@@ -10,6 +10,7 @@ SUPPORTED_RUNTIMES = {
     "python3.11",
     "python3.12",
     "python3.13",
+    "python3.14",
     "nodejs20.x",
     "nodejs22.x",
 }

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -45,6 +45,24 @@ def test_load_manifest_rejects_unknown_runtime(tmp_path: Path):
         load_manifest(bad)
 
 
+def test_load_manifest_accepts_python314(tmp_path: Path):
+    ok = tmp_path / "lambdas.toml"
+    ok.write_text(
+        "[[lambda]]\n"
+        'logical_name = "app"\n'
+        'source_dir = "app"\n'
+        'requirements_lock = "app/requirements.arm64.lock"\n'
+        'runtime = "python3.14"\n'
+        'arch = "arm64"\n'
+        'handler = "app.lambda_handler"\n'
+        "\n"
+        "[builder]\n"
+        'base_image_python = "public.ecr.aws/lambda/python:3.14@sha256:' + "0" * 64 + '"\n'
+    )
+    manifest = load_manifest(ok)
+    assert manifest.lambdas[0].runtime == "python3.14"
+
+
 def test_load_manifest_rejects_unknown_arch(tmp_path: Path):
     bad = tmp_path / "lambdas.toml"
     bad.write_text(


### PR DESCRIPTION
Add `python3.14` to `SUPPORTED_RUNTIMES` so manifests can target the GA python3.14 Lambda runtime. The `public.ecr.aws/lambda/python:3.14` base image is published (multi-arch incl arm64), so callers can pin it as `base_image_python`. Covered by a new manifest-load test (`test_load_manifest_accepts_python314`); manifest suite green (9 passed).

After merge + a release, callers using `uvx --from repro-lambda` pick up python3.14 support.