### PR TITLE
docs: split SETUP into SETUP+USAGE, add runnable terraform example, restructure README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,177 +1,21 @@
-Apache License
-Version 2.0, January 2004
+MIT License
 
-http://www.apache.org/licenses/
+Copyright (c) 2026 Anton Babenko
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-1. Definitions.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-   "License" shall mean the terms and conditions for use, reproduction,
-   and distribution as defined in Sections 1 through 9 of this document.
-
-   "Licensor" shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   "Legal Entity" shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   "control" means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   "You" (or "Your") shall mean an individual or Legal Entity exercising
-   permissions granted by this License.
-
-   "Source" form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   "Object" form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   "Work" shall mean the work of authorship, whether in Source or Object
-   form, made available under the License, as indicated by a copyright
-   notice that is included in or attached to the work (an example is
-   provided in the Appendix below).
-
-   "Derivative Works" shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   "Contribution" shall mean any work of authorship, including
-   the original Work and any Derivative Works thereof, that is intentionally
-   submitted to, or received by, Licensor for inclusion in the Work
-   by the copyright owner or by an individual or Legal Entity authorized
-   to submit on behalf of the copyright owner. For the purposes of this
-   definition, "submitted" means any form of electronic, verbal, or
-   written communication sent to the Licensor or its representatives,
-   including but not limited to communication on electronic mailing lists,
-   source code control systems, and issue tracking systems that are
-   managed by, or on behalf of, the Licensor for the purpose of
-   discussing and improving the Work, but excluding communication
-   that is conspicuously marked or otherwise designated in writing by
-   the copyright owner as "Not a Contribution."
-
-   "Contributor" shall mean any individual or Legal Entity on behalf
-   of whom a Contribution has been received by Licensor and subsequently
-   incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a "NOTICE" text file, then any
-       Derivative Works that You distribute must include a readable
-       copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE from the Work, provided that
-       such additional attribution notices cannot be construed as
-       modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions of this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contribution.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,32 +11,53 @@ instead of building during `terraform plan`/`apply`.
 
     pip install repro-lambda
 
-## Usage
+## Quick start
 
-    repro-lambda init           # scaffold lambdas.toml and CI caller workflow
-    repro-lambda lock           # regenerate per-arch lockfiles
-    repro-lambda build          # build all lambdas in lambdas.toml, upload to S3
-    repro-lambda build --verify # two-pass byte-reproducibility check
+    repro-lambda lock                     # regenerate per-arch requirement + source locks
+    repro-lambda build --bucket <bucket>  # build all lambdas in lambdas.toml, upload to S3
+    repro-lambda build --verify --dry-run # two-pass byte-reproducibility check (no upload)
+    repro-lambda promote \
+      --dev-bucket <dev> --prod-bucket <prod>  # copy dev -> prod by content sha (no rebuild)
 
-See `docs/` for full design.
+`--bucket` (or `REPRO_LAMBDA_BUCKET`) is required for a real build; add
+`--dry-run` to build without uploading. There is no `init` command yet (the
+subcommand is currently a stub).
 
-## Release
+## Documentation
 
-Releases are tag-driven. To cut v0.2.1:
+What each document covers, by section:
 
-    git tag v0.2.1
-    git push origin v0.2.1
+### Setup - one-time AWS provisioning ([SETUP.md](./SETUP.md))
 
-The `publish.yml` workflow uses PyPI Trusted Publishing (OIDC) — no PyPI token
-needed in repo secrets. Configure once via PyPI's "Publishing" panel:
+Provision the supporting infrastructure once per AWS account and environment.
 
-- Owner: `antonbabenko`
-- Repository: `repro-lambda`
-- Workflow: `publish.yml`
-- Environment: (leave blank)
+- [Architecture](./SETUP.md#architecture) - artifact buckets, key-level immutability, the content-hash model
+- [Terraform - per-account bootstrap](./SETUP.md#terraform---per-account-bootstrap) - the buckets, the GitHub OIDC builder role, and outputs
+- [GitHub OIDC provider](./SETUP.md#github-oidc-provider) - declaring the shared per-account OIDC provider
+- [Next steps](./SETUP.md#next-steps) - where to go after provisioning
 
-## Setup
+### Usage - day-to-day ([USAGE.md](./USAGE.md))
 
-See [SETUP.md](./SETUP.md) for a copy-paste-able guide to provisioning the
-S3 buckets, IAM OIDC role, and CI workflow needed to use `repro-lambda` in
-your project.
+Using `repro-lambda` once the infrastructure exists.
+
+- [Source-repo CI workflow](./USAGE.md#source-repo-ci-workflow) - wiring the reusable build workflow into CI/CD
+- [Per-Lambda manifest](./USAGE.md#per-lambda-manifest) - the `lambdas.toml` fields
+  - [Per-lambda builder overrides](./USAGE.md#per-lambda-builder-overrides) - per-lambda base image and file filters
+- [Declarative sources](./USAGE.md#declarative-sources---lambdasource) - pinned external artifacts via `[[lambda.source]]`
+- [Terraform consumer (`s3_existing_package`)](./USAGE.md#terraform-consumer---s3_existing_package) - wiring `terraform-aws-modules/lambda/aws` to the built artifact
+- [Smoke test](./USAGE.md#smoke-test) - first-build verification and the clean migration plan diff
+- [Troubleshooting](./USAGE.md#troubleshooting) - upload 403s, `PreconditionFailed`, noisy plans
+- [Node.js (npm) Lambdas](./USAGE.md#nodejs-npm-lambdas) - npm packaging support
+  - [Manifest fields for npm specs](./USAGE.md#manifest-fields-for-npm-specs)
+  - [Lockfile regeneration](./USAGE.md#lockfile-regeneration)
+- [Lambda@Edge example](./USAGE.md#lambdaedge-example) - `us-east-1` artifacts for CloudFront
+- [Caveats](./USAGE.md#caveats) - npm workspaces, native deps, symlinks
+
+### Example - runnable ([examples/complete/](./examples/complete/))
+
+A self-contained consumer setup: manifest, catalog, and Terraform using
+`terraform-aws-modules/lambda/aws`.
+
+- [What this example shows](./examples/complete/README.md#what-this-example-shows) - files and layout
+- [The build-outside-Terraform flow](./examples/complete/README.md#the-build-outside-terraform-flow) - build, inspect the catalog, apply
+- [Expected plan diff](./examples/complete/README.md#expected-plan-diff) - the `s3_key`-only diff to expect

--- a/README.md
+++ b/README.md
@@ -61,3 +61,11 @@ A self-contained consumer setup: manifest, catalog, and Terraform using
 - [What this example shows](./examples/complete/README.md#what-this-example-shows) - files and layout
 - [The build-outside-Terraform flow](./examples/complete/README.md#the-build-outside-terraform-flow) - build, inspect the catalog, apply
 - [Expected plan diff](./examples/complete/README.md#expected-plan-diff) - the `s3_key`-only diff to expect
+
+## License
+
+MIT - see [LICENSE](./LICENSE).
+
+## Author
+
+Anton Babenko - [@antonbabenko](https://twitter.com/antonbabenko) on Twitter, [antonbabenko](https://www.linkedin.com/in/antonbabenko/) on LinkedIn.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,11 +1,15 @@
 # Setting up `repro-lambda` for your project
 
 `repro-lambda` builds and uploads Lambda artifacts to S3 outside of Terraform.
-For Terraform to read those artifacts via `s3_existing_package`, you need to
-provision the supporting AWS infrastructure once per AWS account and region.
+This guide covers the one-time job: provisioning the supporting AWS
+infrastructure (the artifact buckets plus the GitHub OIDC builder role) once per
+AWS account and region, so that Terraform can later read those artifacts via
+`s3_existing_package`.
 
-This guide is a copy-paste-able reference. Adapt the names and account IDs to
-your environment.
+This is a copy-paste-able reference. Adapt the names and account IDs to your
+environment. Once the infrastructure exists, see [USAGE.md](./USAGE.md) for
+day-to-day use (the CI workflow, the per-Lambda manifest, and consuming
+artifacts from Terraform).
 
 ## Architecture
 
@@ -13,7 +17,7 @@ For each environment (e.g. `dev`, `prod`) you typically need:
 
 ```
 ${env}-my-lambda-artifacts            S3 bucket, region = eu-west-1 (or your primary region)
-${env}-my-lambda-artifacts-us-east-1  S3 bucket, region = us-east-1 (for Lambda@Edge — optional)
+${env}-my-lambda-artifacts-us-east-1  S3 bucket, region = us-east-1 (for Lambda@Edge - optional)
 
 gha-lambda-builder-${env}             IAM role, assumed via GitHub OIDC by source-repo CI to upload
 ```
@@ -28,7 +32,7 @@ Once an artifact with a content-hash key (`lambdas/<name>/<sha256>.zip`) is
 uploaded, the key is permanently bound to those bytes. `repro-lambda` treats
 HTTP 412 PreconditionFailed on a duplicate upload as success.
 
-## Terraform — per-account bootstrap
+## Terraform - per-account bootstrap
 
 The Terraform below assumes you already have a configured AWS provider in the
 target account. Drop it into your bootstrap directory (or anywhere you provision
@@ -47,7 +51,7 @@ locals {
   lambda_artifacts_bucket_us_east_1 = "${local.env}-my-lambda-artifacts-us-east-1"
 
   # GitHub OIDC subjects allowed to assume the builder role.
-  # Pattern: repo:<owner>/<repo>:* — narrow to specific refs in production.
+  # Pattern: repo:<owner>/<repo>:* - narrow to specific refs in production.
   lambda_builder_oidc_subjects = [
     "repo:my-org/my-source-repo:*",
   ]
@@ -147,7 +151,7 @@ module "lambda_artifacts_bucket_primary" {
   force_destroy = false
 }
 
-# us-east-1 bucket — only needed for Lambda@Edge. Remove if not using L@E.
+# us-east-1 bucket - only needed for Lambda@Edge. Remove if not using L@E.
 module "lambda_artifacts_bucket_us_east_1" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 4.0"
@@ -223,12 +227,16 @@ output "gha_lambda_builder_role_arn" {
 }
 ```
 
-> Note: if you only use a single region (no Lambda@Edge), delete the
-> `lambda_artifacts_bucket_us_east_1` module and the `us_east_1` provider alias.
-> The OIDC role policy only needs the primary bucket then.
+> Note: if you only use a single region (no Lambda@Edge), remove every
+> us-east-1 reference together, or `terraform plan` fails on dangling
+> references: the `lambda_artifacts_bucket_us_east_1` module, the `us_east_1`
+> provider alias, the `local.lambda_artifacts_bucket_us_east_1` entry in the
+> immutability policy `for_each`, and the two
+> `module.lambda_artifacts_bucket_us_east_1` ARNs in the OIDC role's
+> `WriteLambdaArtifacts` resources.
 
 Apply the Terraform once per environment. The bucket names and role ARN are
-referenced by your source repos' CI workflows below.
+referenced by your source repos' CI workflows in [USAGE.md](./USAGE.md).
 
 ## GitHub OIDC provider
 
@@ -242,345 +250,13 @@ module "iam_github_oidc_provider" {
 }
 ```
 
-The provider is shared per AWS account — declare it once, not per environment.
+The provider is shared per AWS account - declare it once, not per environment.
 
-## Source-repo CI workflow
+## Next steps
 
-In each repo that builds a Lambda, add a thin caller workflow that delegates to
-the reusable workflow in `antonbabenko/repro-lambda`:
+The AWS infrastructure is now provisioned. To use it day-to-day:
 
-```yaml
-# .github/workflows/build-lambdas.yml
-name: build-lambdas
-
-on:
-  pull_request:
-  push:
-    branches: [master]
-
-jobs:
-  build:
-    uses: antonbabenko/repro-lambda/.github/workflows/build.yml@v0
-    with:
-      manifest_path: lambdas.toml
-      aws_dev_role_arn: arn:aws:iam::<dev-account-id>:role/gha-lambda-builder-dev
-      dev_bucket: <env>-lambda-artifacts
-      # Optional - master-push upload to a prod bucket:
-      # aws_prod_role_arn: arn:aws:iam::<prod-account-id>:role/gha-lambda-builder-prod
-      # prod_bucket: <env>-lambda-artifacts
-```
-
-Pin the reusable workflow with the sliding major tag `@v0` - it auto-moves to the
-latest backward-compatible 0.x release on every tag (switch to `@v1` once repro-lambda
-ships 1.0). The role ARNs are not secrets: the boundary is the OIDC trust policy plus
-the key-level bucket immutability, so they are plain inputs (only the account IDs,
-which are public), not stored secrets.
-
-## Per-Lambda manifest
-
-Each consumer repo defines a `lambdas.toml` at its root:
-
-```toml
-[[lambda]]
-logical_name      = "app"
-source_dir        = "src/app"
-requirements_lock = "src/app/requirements.${arch}.lock"
-runtime           = "python3.13"
-arch              = "arm64"
-handler           = "app.lambda_handler"
-region            = "eu-west-1"
-package_manager   = "pip"
-lambda_at_edge    = false
-hash_extra        = ""
-
-[builder]
-base_image_python = "public.ecr.aws/lambda/python:3.13@sha256:<pinned-digest>"
-include_patterns  = ["**/*.py", "**/*.json"]
-exclude_patterns  = [".venv/**", "__pycache__/**", "*.pyc", ".git/**", ".env*"]
-```
-
-Pin the `base_image_python` to a specific digest with `docker pull <image> &&
-docker inspect --format='{{index .RepoDigests 0}}' <image>` — never use a
-floating tag in production.
-
-### Per-lambda builder overrides
-
-`[builder]` sets the defaults for every lambda. Any `[[lambda]]` may override
-`base_image_python`, `include_patterns`, or `exclude_patterns` for itself. An
-override REPLACES the default for that field (lists are not merged); an unset
-field inherits `[builder]`. Use this when one lambda needs a different base image
-or a tighter file filter (so it re-hashes only on changes that affect it):
-
-```toml
-[[lambda]]
-logical_name      = "worker"
-source_dir        = "src/worker"
-requirements_lock = "src/worker/requirements.${arch}.lock"
-runtime           = "python3.13"
-arch              = "arm64"
-handler           = "worker.handler"
-# Override: only this lambda's runtime modules trigger a rebuild, and it builds
-# on its own pinned base image. base_image_python must still be digest-pinned.
-base_image_python = "public.ecr.aws/lambda/python:3.13@sha256:<other-digest>"
-include_patterns  = ["worker/**/*.py", "worker/**/*.json"]
-exclude_patterns  = ["**/tests/**"]
-```
-
-The resolved per-lambda builder (base-image digest + include/exclude lists +
-builder version) folds into the content hash, so changing an override re-keys
-that lambda's artifact while leaving the others untouched.
-
-## Declarative sources — `[[lambda.source]]`
-
-A lambda can bundle pinned external artifacts (a release tarball, a vendored CLI
-binary) fetched at build time, instead of a hand-rolled download script. Each
-`[[lambda.source]]` is fully pinned and fetched + verified + extracted into the
-package before the container build:
-
-```toml
-[[lambda]]
-logical_name      = "app"
-source_dir        = "src/app"
-requirements_lock = "src/app/requirements.${arch}.lock"
-runtime           = "python3.13"
-arch              = "arm64"
-handler           = "app.lambda_handler"
-
-# A private GitHub release tarball -> staged at package path "vendor".
-[[lambda.source]]
-name    = "vendor"
-type    = "github_release"
-repo    = "owner/vendor-tool"
-tag     = "vendor-v{version}"
-asset   = "vendor-{version}.tar.gz"
-sha256  = "<64-hex; written by `repro-lambda lock`>"
-extract = "tar.gz"
-member  = "vendor-{version}"   # map the versioned top dir to dest
-dest    = "vendor"
-version = "1.4.0"              # bump this one line; lock re-pins everything
-
-# A public binary whose version is derived from the vendor release's .tool-versions.
-[[lambda.source]]
-name    = "terraform"
-type    = "https"
-url     = "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_linux_arm64.zip"
-sha256  = "<64-hex; written by lock>"
-extract = "zip"
-member  = "terraform"
-dest    = "bin/terraform"
-executable = true
-version = "1.9.0"
-[lambda.source.version_from]
-source = "vendor"          # read from the vendor source's extracted tree
-file   = ".tool-versions"  # relative to its member-stripped root
-key    = "terraform"
-```
-
-- **Pinning.** `sha256` is verified before the archive is opened. `extract` is
-  `zip` / `tar.gz` / `none`. `member` extracts one file or a directory subtree to
-  `dest`; omit it to extract the whole archive under `dest`. Source names are
-  unique per lambda and dests may not overlap each other or the staged source.
-- **`version_from`** (single-level) derives a source's `version` from an asdf-style
-  `key value` line in another source's file, so bumping the root `version`
-  cascades to dependents. It is a lock input - it never affects the artifact hash.
-- **`repro-lambda lock`** re-resolves `version_from`, re-downloads, recomputes each
-  `sha256`, and rewrites this file (comment-preserving, atomic, idempotent). Run it
-  after bumping a `version`. Pass `REPRO_LAMBDA_SOURCES_TOKEN` for private
-  `github_release` sources.
-- **Security.** Fetches are HTTPS-only with an SSRF guard (no private/loopback/
-  link-local/metadata IPs), strip `Authorization` on cross-host redirects, verify
-  sha256 before extraction, and reject path-traversal / link / device entries with
-  decompression-bomb bounds. See `src/repro_lambda/sources.py`.
-
-In CI, pass the token to the reusable `build.yml` as the `sources_token` secret:
-
-```yaml
-jobs:
-  build:
-    uses: antonbabenko/repro-lambda/.github/workflows/build.yml@v0
-    with:
-      manifest_path: lambdas.toml
-      aws_dev_role_arn: arn:aws:iam::<account>:role/<dev-builder-role>
-      dev_bucket: <env>-my-lambda-artifacts
-    secrets:
-      sources_token: ${{ secrets.MY_RELEASE_TOKEN }}
-```
-
-## Terraform consumer — `s3_existing_package`
-
-In the Terraform that creates your Lambda function, point at the artifact in
-S3 instead of building inline:
-
-```hcl
-locals {
-  lambda_manifest = jsondecode(file("${path.module}/builds/catalog.json"))
-}
-
-module "lambda_app" {
-  source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 8.0"
-
-  function_name = "my-app"
-  runtime       = "python3.13"
-  architectures = ["arm64"]
-  handler       = "app.lambda_handler"
-  publish       = true
-
-  s3_existing_package = {
-    bucket         = "${var.env}-my-lambda-artifacts"
-    key            = "lambdas/app/${local.lambda_manifest.lambdas.app.current}.zip"
-    object_version = null
-  }
-}
-```
-
-For Lambda@Edge, point at the `-us-east-1` bucket and set `lambda_at_edge = true`
-in the Terraform module.
-
-## Smoke test
-
-After applying the bootstrap Terraform and configuring CI secrets:
-
-```bash
-# In your consumer repo
-gh workflow run build-lambdas.yml
-# Wait for completion, then check that the artifact landed
-aws s3 ls s3://dev-my-lambda-artifacts/lambdas/app/
-```
-
-The first PR after migration should show a Terraform plan whose only diff is the
-`s3_key` change. If you see `last_modified`, `qualified_arn`, `version`,
-`local_file.archive_plan`, or `null_resource.archive` mentioned, the migration
-is incomplete — review your Lambda module call and remove the legacy build
-attributes (`source_path`, `build_in_docker`, `trigger_on_package_timestamp`,
-`ignore_source_code_hash`, `hash_extra`, `local_existing_package`,
-`store_on_s3`).
-
-## Troubleshooting
-
-- **`403 AccessDenied` on upload**: the OIDC role doesn't have `s3:PutObject` on
-  the bucket. Check the inline policy resources include both the bucket ARN and
-  `${bucket_arn}/*`.
-- **`PreconditionFailed` on every upload**: the artifact already exists with
-  that sha. This is the expected cache-hit behavior; `repro-lambda` treats it
-  as success.
-- **AWS CLI multipart upload fails with 403**: bucket policy denies multipart
-  parts. Pin the multipart threshold above your Lambda size cap:
-  `aws configure set s3.multipart_threshold 300MB`.
-- **Plan still shows noisy diff after migration**: verify the consumer Terraform
-  removed every legacy attribute and that the catalog sha read by `jsondecode`
-  matches the sha in the S3 key. The plan diff should be exactly `~ s3_key =
-  "<old>.zip" -> "<new>.zip"` and nothing else.
-
-## Node.js (npm) Lambdas
-
-`repro-lambda` v0.2 adds Node.js Lambda packaging. The build runs `npm ci` in
-the digest-pinned Node base image, then packs the resulting `pkg/` directory
-inside the digest-pinned Python base image (Python is the only language with
-deterministic-zip tooling pre-installed in the AWS Lambda runtime images, so
-its zlib is the only deflate implementation invoked - macOS arm64 hosts and
-Linux x86_64 CI produce byte-identical output).
-
-### Manifest fields for npm specs
-
-```toml
-[[lambda]]
-logical_name      = "api"
-source_dir        = "src/api"
-requirements_lock = "src/api/package-lock.json"   # npm lockfile
-package_json      = "src/api/package.json"        # REQUIRED for npm specs
-runtime           = "nodejs22.x"                  # or "nodejs20.x"
-arch              = "x86_64"                      # or "arm64"
-handler           = "index.handler"
-region            = "eu-west-1"
-package_manager   = "npm"
-lambda_at_edge    = false
-hash_extra        = ""
-
-[builder]
-base_image_python = "public.ecr.aws/lambda/python:3.13@sha256:<pinned-digest>"
-base_image_nodejs = "public.ecr.aws/lambda/nodejs:22@sha256:<pinned-digest>"
-include_patterns  = ["**/*.js", "**/*.json"]
-exclude_patterns  = [".git/**", "node_modules/**", "*.md", "LICENSE*", "CHANGELOG*"]
-```
-
-Pin both base images by digest:
-
-```bash
-docker pull public.ecr.aws/lambda/nodejs:22
-docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/lambda/nodejs:22
-```
-
-### Lockfile regeneration
-
-`repro-lambda lock` only regenerates per-arch Python lockfiles via `uv pip
-compile`. For npm specs it prints `skip <name>: npm uses package-lock.json
-directly`. Regenerate the npm lockfile upstream with:
-
-```bash
-cd src/api
-npm install --package-lock-only
-git add package-lock.json
-```
-
-The lockfile and `package.json` both contribute to the artifact content hash;
-editing either bumps the S3 key.
-
-## Lambda@Edge example
-
-Lambda@Edge functions must be deployed to `us-east-1`, regardless of where the
-CloudFront distribution serves traffic. Set `region = "us-east-1"` and
-`lambda_at_edge = true` in the manifest; `repro-lambda` will upload to the
-`*-us-east-1` artifact bucket automatically.
-
-```toml
-[[lambda]]
-logical_name      = "edge"
-source_dir        = "src/edge"
-requirements_lock = "src/edge/package-lock.json"
-package_json      = "src/edge/package.json"
-runtime           = "nodejs22.x"
-arch              = "x86_64"               # L@E currently requires x86_64
-handler           = "index.handler"
-region            = "us-east-1"
-package_manager   = "npm"
-lambda_at_edge    = true
-```
-
-Consumer Terraform points at the us-east-1 bucket:
-
-```hcl
-module "lambda_edge" {
-  source  = "terraform-aws-modules/lambda/aws"
-  version = "~> 8.0"
-  providers = { aws = aws.us_east_1 }
-
-  function_name  = "my-edge"
-  runtime        = "nodejs22.x"
-  architectures  = ["x86_64"]
-  handler        = "index.handler"
-  publish        = true
-  lambda_at_edge = true
-
-  s3_existing_package = {
-    bucket = "${var.env}-my-lambda-artifacts-us-east-1"
-    key    = "lambdas/edge/${local.lambda_manifest.lambdas.edge.current}.zip"
-  }
-}
-```
-
-## Caveats
-
-- **No npm workspaces.** v0.2 supports a single `package.json` per Lambda. If
-  your repo uses workspaces, copy the published package into a single-package
-  layout per Lambda before invoking `repro-lambda`.
-- **Native dependencies need `optionalDependencies` arms.** `npm ci --cpu=${arch}
-  --os=linux` cannot cross-compile native modules. A dep with native code must
-  ship a `linux-${arch}` binary via its `package-lock.json`
-  `optionalDependencies` arm (the lockfile-v3 standard mechanism). If it
-  doesn't, the build runs on the host arch and may produce a non-portable
-  artifact.
-- **Symlinks in source are skipped.** `pack_directory` skips symlinks and
-  prints a stderr warning; the resulting zip cannot preserve link semantics.
-  If your build relies on symlinks (e.g. monorepo references), replace them
-  with the file contents.
+- [USAGE.md](./USAGE.md) - the source-repo CI workflow, the per-Lambda manifest,
+  declarative sources, consuming artifacts from Terraform, and troubleshooting.
+- [examples/complete/](./examples/complete/) - a runnable example that wires the
+  pieces together.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,350 @@
+# Using `repro-lambda`
+
+Day-to-day usage of `repro-lambda` once the AWS infra from [SETUP.md](./SETUP.md)
+is provisioned. The working commands are `build`, `promote`, and `lock` (plus an
+internal `zip` step); `init` is currently a stub and is not yet implemented.
+
+## Source-repo CI workflow
+
+In each repo that builds a Lambda, add a thin caller workflow that delegates to
+the reusable workflow in `antonbabenko/repro-lambda`:
+
+```yaml
+# .github/workflows/build-lambdas.yml
+name: build-lambdas
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    uses: antonbabenko/repro-lambda/.github/workflows/build.yml@v0
+    with:
+      manifest_path: lambdas.toml
+      aws_dev_role_arn: arn:aws:iam::<dev-account-id>:role/gha-lambda-builder-dev
+      dev_bucket: <dev-env>-my-lambda-artifacts
+      # Optional - master-push upload to a prod bucket:
+      # aws_prod_role_arn: arn:aws:iam::<prod-account-id>:role/gha-lambda-builder-prod
+      # prod_bucket: <prod-env>-my-lambda-artifacts
+```
+
+Pin the reusable workflow with the sliding major tag `@v0` - it auto-moves to the
+latest backward-compatible 0.x release on every tag (switch to `@v1` once repro-lambda
+ships 1.0). The role ARNs are not secrets: the boundary is the OIDC trust policy plus
+the key-level bucket immutability, so they are plain inputs (only the account IDs,
+which are public), not stored secrets.
+
+## Per-Lambda manifest
+
+Each consumer repo defines a `lambdas.toml` at its root:
+
+```toml
+[[lambda]]
+logical_name      = "app"
+source_dir        = "src/app"
+requirements_lock = "src/app/requirements.${arch}.lock"
+runtime           = "python3.13"
+arch              = "arm64"
+handler           = "app.lambda_handler"
+region            = "eu-west-1"
+package_manager   = "pip"
+lambda_at_edge    = false
+hash_extra        = ""
+
+[builder]
+base_image_python = "public.ecr.aws/lambda/python:3.13@sha256:<pinned-digest>"
+include_patterns  = ["**/*.py", "**/*.json"]
+exclude_patterns  = [".venv/**", "__pycache__/**", "*.pyc", ".git/**", ".env*"]
+```
+
+Pin the `base_image_python` to a specific digest with `docker pull <image> &&
+docker inspect --format='{{index .RepoDigests 0}}' <image>` - never use a
+floating tag in production.
+
+### Per-lambda builder overrides
+
+`[builder]` sets the defaults for every lambda. Any `[[lambda]]` may override
+`base_image_python`, `include_patterns`, or `exclude_patterns` for itself. An
+override REPLACES the default for that field (lists are not merged); an unset
+field inherits `[builder]`. Use this when one lambda needs a different base image
+or a tighter file filter (so it re-hashes only on changes that affect it):
+
+```toml
+[[lambda]]
+logical_name      = "worker"
+source_dir        = "src/worker"
+requirements_lock = "src/worker/requirements.${arch}.lock"
+runtime           = "python3.13"
+arch              = "arm64"
+handler           = "worker.handler"
+# Override: only this lambda's runtime modules trigger a rebuild, and it builds
+# on its own pinned base image. base_image_python must still be digest-pinned.
+base_image_python = "public.ecr.aws/lambda/python:3.13@sha256:<other-digest>"
+include_patterns  = ["worker/**/*.py", "worker/**/*.json"]
+exclude_patterns  = ["**/tests/**"]
+```
+
+The resolved per-lambda builder (base-image digest + include/exclude lists +
+builder version) folds into the content hash, so changing an override re-keys
+that lambda's artifact while leaving the others untouched.
+
+## Declarative sources - `[[lambda.source]]`
+
+A lambda can bundle pinned external artifacts (a release tarball, a vendored CLI
+binary) fetched at build time, instead of a hand-rolled download script. Each
+`[[lambda.source]]` is fully pinned and fetched + verified + extracted into the
+package before the container build:
+
+```toml
+[[lambda]]
+logical_name      = "app"
+source_dir        = "src/app"
+requirements_lock = "src/app/requirements.${arch}.lock"
+runtime           = "python3.13"
+arch              = "arm64"
+handler           = "app.lambda_handler"
+
+# A private GitHub release tarball -> staged at package path "vendor".
+[[lambda.source]]
+name    = "vendor"
+type    = "github_release"
+repo    = "owner/vendor-tool"
+tag     = "vendor-v{version}"
+asset   = "vendor-{version}.tar.gz"
+sha256  = "<64-hex; written by `repro-lambda lock`>"
+extract = "tar.gz"
+member  = "vendor-{version}"   # map the versioned top dir to dest
+dest    = "vendor"
+version = "1.4.0"              # bump this one line; lock re-pins everything
+
+# A public binary whose version is derived from the vendor release's .tool-versions.
+[[lambda.source]]
+name    = "terraform"
+type    = "https"
+url     = "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_linux_arm64.zip"
+sha256  = "<64-hex; written by lock>"
+extract = "zip"
+member  = "terraform"
+dest    = "bin/terraform"
+executable = true
+version = "1.9.0"
+[lambda.source.version_from]
+source = "vendor"          # read from the vendor source's extracted tree
+file   = ".tool-versions"  # relative to its member-stripped root
+key    = "terraform"
+```
+
+- **Pinning.** `sha256` is verified before the archive is opened. `extract` is
+  `zip` / `tar.gz` / `none`. `member` extracts one file or a directory subtree to
+  `dest`; omit it to extract the whole archive under `dest`. Source names are
+  unique per lambda and dests may not overlap each other or the staged source.
+- **`version_from`** (single-level) derives a source's `version` from an asdf-style
+  `key value` line in another source's file, so bumping the root `version`
+  cascades to dependents. It is a lock input - it never affects the artifact hash.
+- **`repro-lambda lock`** re-resolves `version_from`, re-downloads, recomputes each
+  `sha256`, and rewrites this file (comment-preserving, atomic, idempotent). Run it
+  after bumping a `version`. Pass `REPRO_LAMBDA_SOURCES_TOKEN` for private
+  `github_release` sources.
+- **Security.** Fetches are HTTPS-only with an SSRF guard (no private/loopback/
+  link-local/metadata IPs), strip `Authorization` on cross-host redirects, verify
+  sha256 before extraction, and reject path-traversal / link / device entries with
+  decompression-bomb bounds. See `src/repro_lambda/sources.py`.
+
+In CI, pass the token to the reusable `build.yml` as the `sources_token` secret:
+
+```yaml
+jobs:
+  build:
+    uses: antonbabenko/repro-lambda/.github/workflows/build.yml@v0
+    with:
+      manifest_path: lambdas.toml
+      aws_dev_role_arn: arn:aws:iam::<account>:role/<dev-builder-role>
+      dev_bucket: <dev-env>-my-lambda-artifacts
+    secrets:
+      sources_token: ${{ secrets.MY_RELEASE_TOKEN }}
+```
+
+## Terraform consumer - `s3_existing_package`
+
+In the Terraform that creates your Lambda function, point at the artifact in
+S3 instead of building inline:
+
+```hcl
+locals {
+  lambda_manifest = jsondecode(file("${path.module}/builds/catalog.json"))
+}
+
+module "lambda_app" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "~> 8.0"
+
+  function_name = "my-app"
+  runtime       = "python3.13"
+  architectures = ["arm64"]
+  handler       = "app.lambda_handler"
+  publish       = true
+
+  s3_existing_package = {
+    bucket = "${var.env}-my-lambda-artifacts"
+    key    = "lambdas/app/${local.lambda_manifest.lambdas.app.current}.zip"
+  }
+}
+```
+
+For Lambda@Edge, point at the `-us-east-1` bucket and set `lambda_at_edge = true`
+in the Terraform module.
+
+For a full runnable version that wires the bootstrap, CI, and this consumer
+module together, see [examples/complete/](./examples/complete/).
+
+## Smoke test
+
+After applying the bootstrap Terraform and configuring CI secrets:
+
+```bash
+# In your consumer repo
+gh workflow run build-lambdas.yml
+# Wait for completion, then check that the artifact landed
+aws s3 ls s3://dev-my-lambda-artifacts/lambdas/app/
+```
+
+The first PR after migration should show a Terraform plan whose only diff is the
+`s3_key` change. If you see `last_modified`, `qualified_arn`, `version`,
+`local_file.archive_plan`, or `null_resource.archive` mentioned, the migration
+is incomplete - review your Lambda module call and remove the legacy build
+attributes (`source_path`, `build_in_docker`, `trigger_on_package_timestamp`,
+`ignore_source_code_hash`, `hash_extra`, `local_existing_package`,
+`store_on_s3`).
+
+## Troubleshooting
+
+- **`403 AccessDenied` on upload**: the OIDC role doesn't have `s3:PutObject` on
+  the bucket. Check the inline policy resources include both the bucket ARN and
+  `${bucket_arn}/*`.
+- **`PreconditionFailed` on every upload**: the artifact already exists with
+  that sha. This is the expected cache-hit behavior; `repro-lambda` treats it
+  as success.
+- **AWS CLI multipart upload fails with 403**: bucket policy denies multipart
+  parts. Pin the multipart threshold above your Lambda size cap:
+  `aws configure set s3.multipart_threshold 300MB`.
+- **Plan still shows noisy diff after migration**: verify the consumer Terraform
+  removed every legacy attribute and that the catalog sha read by `jsondecode`
+  matches the sha in the S3 key. The plan diff should be exactly `~ s3_key =
+  "<old>.zip" -> "<new>.zip"` and nothing else.
+
+## Node.js (npm) Lambdas
+
+Since v0.2, `repro-lambda` supports Node.js Lambda packaging. The build runs
+`npm ci` in the digest-pinned Node base image, then packs the resulting `pkg/`
+directory inside the digest-pinned Python base image (Python is the only
+language with deterministic-zip tooling pre-installed in the AWS Lambda runtime
+images, so its zlib is the only deflate implementation invoked - macOS arm64
+hosts and Linux x86_64 CI produce byte-identical output).
+
+### Manifest fields for npm specs
+
+```toml
+[[lambda]]
+logical_name      = "api"
+source_dir        = "src/api"
+requirements_lock = "src/api/package-lock.json"   # npm lockfile
+package_json      = "src/api/package.json"        # REQUIRED for npm specs
+runtime           = "nodejs22.x"                  # or "nodejs20.x"
+arch              = "x86_64"                      # or "arm64"
+handler           = "index.handler"
+region            = "eu-west-1"
+package_manager   = "npm"
+lambda_at_edge    = false
+hash_extra        = ""
+
+[builder]
+base_image_python = "public.ecr.aws/lambda/python:3.13@sha256:<pinned-digest>"
+base_image_nodejs = "public.ecr.aws/lambda/nodejs:22@sha256:<pinned-digest>"
+include_patterns  = ["**/*.js", "**/*.json"]
+exclude_patterns  = [".git/**", "node_modules/**", "*.md", "LICENSE*", "CHANGELOG*"]
+```
+
+Pin both base images by digest:
+
+```bash
+docker pull public.ecr.aws/lambda/nodejs:22
+docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/lambda/nodejs:22
+```
+
+### Lockfile regeneration
+
+`repro-lambda lock` regenerates per-arch Python requirement lockfiles via `uv
+pip compile` (it also re-pins any `[[lambda.source]]` entries by default; see
+above). The Python requirement step does not apply to npm specs - for those it
+prints `skip <name>: npm uses package-lock.json directly`. Regenerate the npm
+lockfile upstream with:
+
+```bash
+cd src/api
+npm install --package-lock-only
+git add package-lock.json
+```
+
+The lockfile and `package.json` both contribute to the artifact content hash;
+editing either bumps the S3 key.
+
+## Lambda@Edge example
+
+Lambda@Edge functions must be deployed to `us-east-1`, regardless of where the
+CloudFront distribution serves traffic. Set `region = "us-east-1"` and
+`lambda_at_edge = true` in the manifest; `repro-lambda` will upload to the
+`*-us-east-1` artifact bucket automatically.
+
+```toml
+[[lambda]]
+logical_name      = "edge"
+source_dir        = "src/edge"
+requirements_lock = "src/edge/package-lock.json"
+package_json      = "src/edge/package.json"
+runtime           = "nodejs22.x"
+arch              = "x86_64"               # L@E currently requires x86_64
+handler           = "index.handler"
+region            = "us-east-1"
+package_manager   = "npm"
+lambda_at_edge    = true
+```
+
+Consumer Terraform points at the us-east-1 bucket:
+
+```hcl
+module "lambda_edge" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "~> 8.0"
+  providers = { aws = aws.us_east_1 }
+
+  function_name  = "my-edge"
+  runtime        = "nodejs22.x"
+  architectures  = ["x86_64"]
+  handler        = "index.handler"
+  publish        = true
+  lambda_at_edge = true
+
+  s3_existing_package = {
+    bucket = "${var.env}-my-lambda-artifacts-us-east-1"
+    key    = "lambdas/edge/${local.lambda_manifest.lambdas.edge.current}.zip"
+  }
+}
+```
+
+## Caveats
+
+- **No npm workspaces.** v0.2 supports a single `package.json` per Lambda. If
+  your repo uses workspaces, copy the published package into a single-package
+  layout per Lambda before invoking `repro-lambda`.
+- **Native dependencies need `optionalDependencies` arms.** `npm ci --cpu=${arch}
+  --os=linux` cannot cross-compile native modules. A dep with native code must
+  ship a `linux-${arch}` binary via its `package-lock.json`
+  `optionalDependencies` arm (the lockfile-v3 standard mechanism). If it
+  doesn't, the build runs on the host arch and may produce a non-portable
+  artifact.
+- **Symlinks in source are skipped.** `pack_directory` skips symlinks and
+  prints a stderr warning; the resulting zip cannot preserve link semantics.
+  If your build relies on symlinks (e.g. monorepo references), replace them
+  with the file contents.

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -1,0 +1,100 @@
+# Complete repro-lambda example
+
+A self-contained consumer setup showing how `repro-lambda` and Terraform divide
+the work: `repro-lambda` builds a reproducible Lambda zip and uploads it to S3
+outside of Terraform, and Terraform only references that existing object by its
+content-hash key. No build runs during `terraform plan` or `apply`.
+
+## What this example shows
+
+- One Python Lambda named `app` (`python3.13`, `arm64`, region `eu-west-1`).
+- A manifest (`lambdas.toml`) that `repro-lambda` reads to build and upload.
+- A build catalog (`builds/catalog.json`) committed to the repo, holding the
+  current content sha per lambda.
+- Terraform that reads the current sha and points `s3_existing_package` at
+  `lambdas/app/<sha256>.zip` in the artifact bucket.
+
+## Files
+
+```
+examples/complete/
+  README.md                      this file
+  lambdas.toml                   repro-lambda manifest (one python lambda: app)
+  main.tf                        lambda module call using s3_existing_package
+  variables.tf                   env, aws_region
+  versions.tf                    required_version + aws provider + provider block
+  outputs.tf                     lambda_function_arn, lambda_function_name
+  builds/catalog.json            current sha + build history for "app"
+  src/app/app.py                 the handler
+  src/app/requirements.arm64.lock locked deps (empty - no third-party deps)
+```
+
+## The build-outside-Terraform flow
+
+### 1. Build and upload the artifact
+
+`repro-lambda` builds the zip in a digest-pinned container and uploads it to the
+artifact bucket. The S3 key is `lambdas/<logical_name>/<sha256>.zip`.
+
+```bash
+repro-lambda build --bucket dev-my-lambda-artifacts
+```
+
+This also updates `builds/catalog.json` with the new content sha. Commit that
+change to the repo so Terraform reads the matching sha.
+
+### 2. Inspect the catalog
+
+Terraform reads the current sha from `builds/catalog.json`:
+
+```bash
+# What sha will Terraform deploy?
+cat builds/catalog.json
+# Confirm the object exists in S3
+aws s3 ls s3://dev-my-lambda-artifacts/lambdas/app/
+```
+
+### 3. Apply the Terraform
+
+```bash
+terraform init
+terraform apply -var="env=dev"
+```
+
+Terraform reads `local.catalog.lambdas.app.current` and resolves the key
+`lambdas/app/<sha256>.zip`. It does not build anything.
+
+## Expected plan diff
+
+When `app.py` (or its deps, base image, or builder version) changes, the next
+`repro-lambda build` writes a new sha to `builds/catalog.json`. The only
+Terraform plan diff should then be the S3 key:
+
+```
+~ s3_key = "lambdas/app/<old-sha>.zip" -> "lambdas/app/<new-sha>.zip"
+```
+
+If you also see `last_modified`, `qualified_arn`, `source_code_hash`, or any
+`null_resource.archive` / `local_file.archive_plan`, the function is still
+configured to build inline - remove the legacy build attributes. See the
+migration notes in [../../USAGE.md](../../USAGE.md#smoke-test).
+
+## This example will not apply as-is
+
+It documents the flow; it is not expected to `terraform apply` cleanly out of
+the box. Before it can apply you must:
+
+- Provision the artifact bucket and OIDC builder role once per account - see
+  [../../SETUP.md](../../SETUP.md).
+- Replace the placeholders: `<pinned-digest>` in `lambdas.toml`, and any account
+  IDs / bucket names that differ from `${env}-my-lambda-artifacts`.
+- Run `repro-lambda build --bucket <your-bucket>` so a real artifact exists in
+  S3 at the sha recorded in `builds/catalog.json` (the sha shipped here is a
+  placeholder).
+
+## Related docs
+
+- [../../USAGE.md](../../USAGE.md) - day-to-day usage: CI workflow, manifest,
+  and the consumer Terraform reference (`s3_existing_package`).
+- [../../SETUP.md](../../SETUP.md) - one-time account bootstrap (artifact
+  buckets, OIDC builder role).

--- a/examples/complete/builds/catalog.json
+++ b/examples/complete/builds/catalog.json
@@ -1,0 +1,20 @@
+{
+  "lambdas": {
+    "app": {
+      "current": "9f2a3b4c5d6e7f8091a2b3c4d5e6f7081920a3b4c5d6e7f8091a2b3c4d5e6f70",
+      "history": [
+        {
+          "arch": "arm64",
+          "base_image_digest": "sha256:1b2c3d4e5f60718293a4b5c6d7e8f9001122334455667788990aabbccddeeff0",
+          "builder_version": "0.6.0",
+          "built_at": "2026-06-20T09:30:00Z",
+          "region": "eu-west-1",
+          "runtime": "python3.13",
+          "sha256": "9f2a3b4c5d6e7f8091a2b3c4d5e6f7081920a3b4c5d6e7f8091a2b3c4d5e6f70",
+          "source_commit": "a1b2c3d4e5f60718293a4b5c6d7e8f9001122334"
+        }
+      ]
+    }
+  },
+  "schema_version": 1
+}

--- a/examples/complete/lambdas.toml
+++ b/examples/complete/lambdas.toml
@@ -1,0 +1,26 @@
+# repro-lambda manifest for the "complete" example.
+#
+# repro-lambda reads this file to build and upload Lambda artifacts to S3
+# OUTSIDE of Terraform. Run `repro-lambda build --bucket <bucket>` to build
+# every [[lambda]] below; see ../../SETUP.md for the CI workflow.
+
+[[lambda]]
+logical_name      = "app"
+source_dir        = "src/app"
+requirements_lock = "src/app/requirements.${arch}.lock"
+runtime           = "python3.13"
+arch              = "arm64"
+handler           = "app.lambda_handler"
+region            = "eu-west-1"
+package_manager   = "pip"
+lambda_at_edge    = false
+hash_extra        = ""
+
+[builder]
+# Pin base_image_python to a specific digest - never a floating tag in production.
+# Get the digest with:
+#   docker pull public.ecr.aws/lambda/python:3.13
+#   docker inspect --format='{{index .RepoDigests 0}}' public.ecr.aws/lambda/python:3.13
+base_image_python = "public.ecr.aws/lambda/python:3.13@sha256:<pinned-digest>"
+include_patterns  = ["**/*.py", "**/*.json"]
+exclude_patterns  = [".venv/**", "__pycache__/**", "*.pyc", ".git/**", ".env*"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,0 +1,25 @@
+# The Lambda zip referenced below was built and uploaded to S3 by repro-lambda
+# OUTSIDE of Terraform (see ../../SETUP.md and the README in this directory).
+# Terraform never builds the artifact - it only references the existing object
+# in S3 by its content-hash key. The current sha for each lambda is read from
+# builds/catalog.json, which repro-lambda updates on every successful build.
+
+locals {
+  catalog = jsondecode(file("${path.module}/builds/catalog.json"))
+}
+
+module "lambda_app" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "~> 8.0"
+
+  function_name = "${var.env}-app"
+  runtime       = "python3.13"
+  architectures = ["arm64"]
+  handler       = "app.lambda_handler"
+  publish       = true
+
+  s3_existing_package = {
+    bucket = "${var.env}-my-lambda-artifacts"
+    key    = "lambdas/app/${local.catalog.lambdas.app.current}.zip"
+  }
+}

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,0 +1,9 @@
+output "lambda_function_arn" {
+  description = "ARN of the deployed Lambda function."
+  value       = module.lambda_app.lambda_function_arn
+}
+
+output "lambda_function_name" {
+  description = "Name of the deployed Lambda function."
+  value       = module.lambda_app.lambda_function_name
+}

--- a/examples/complete/src/app/app.py
+++ b/examples/complete/src/app/app.py
@@ -1,0 +1,3 @@
+def lambda_handler(event, context):
+    """Minimal handler - returns a static greeting."""
+    return {"statusCode": 200, "body": "hello from repro-lambda"}

--- a/examples/complete/src/app/requirements.arm64.lock
+++ b/examples/complete/src/app/requirements.arm64.lock
@@ -1,0 +1,3 @@
+# Locked dependencies for the "app" lambda (arm64).
+# Regenerate with `repro-lambda lock` (uv pip compile under the hood).
+# This example has no third-party dependencies, so the lock is intentionally empty.

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,0 +1,11 @@
+variable "env" {
+  description = "Deployment environment. Prefixes the artifact bucket name (e.g. dev-my-lambda-artifacts)."
+  type        = string
+  default     = "dev"
+}
+
+variable "aws_region" {
+  description = "AWS region for the provider and the deployed Lambda function."
+  type        = string
+  default     = "eu-west-1"
+}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.6.0"
 description = "Build reproducible AWS Lambda packages outside Terraform, optimized for terraform-aws-lambda by serverless.tf."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "Apache-2.0" }
+license = { text = "MIT" }
 authors = [{ name = "Anton Babenko", email = "anton@antonbabenko.com" }]
 keywords = ["aws", "lambda", "terraform", "reproducible-builds", "serverless"]
 classifiers = [
@@ -12,7 +12,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "License :: OSI Approved :: Apache Software License",
+  "License :: OSI Approved :: MIT License",
   "Operating System :: POSIX :: Linux",
   "Operating System :: MacOS :: MacOS X",
   "Topic :: Software Development :: Build Tools",

--- a/src/repro_lambda/cli.py
+++ b/src/repro_lambda/cli.py
@@ -363,7 +363,7 @@ def _lock_requirements(parsed, repo_root: Path) -> None:
 
 @app.command()
 def init() -> None:
-    """Scaffold lambdas.toml and CI caller workflow."""
+    """Not yet implemented (stub). Will scaffold lambdas.toml and a CI caller workflow."""
     typer.echo("init stub")
     raise typer.Exit(0)
 


### PR DESCRIPTION
## Summary

Restructure the documentation and add a runnable example showing how `repro-lambda` works with `terraform-aws-modules/lambda/aws`.

- Split `SETUP.md` (which mixed one-time provisioning with day-to-day usage) into two:
  - `SETUP.md` - one-time AWS provisioning only (artifact buckets, OIDC builder role, OIDC provider).
  - `USAGE.md` (new) - day-to-day usage: the reusable CI workflow, the per-Lambda manifest and builder overrides, declarative sources, the `terraform-aws-modules/lambda/aws` consumer via `s3_existing_package`, smoke test, troubleshooting, Node.js, Lambda@Edge, and caveats.
- Add `examples/complete/` - a self-contained consumer example: `lambdas.toml`, a committed `builds/catalog.json`, a handler, and Terraform using `terraform-aws-modules/lambda/aws` that reads the artifact via `s3_existing_package`.
- `README.md` - drop the Release section; add a documentation table of contents that links each document's specific subsections, each with a short descriptor of what it covers.

## Factual fixes (verified against the source)

- `s3_existing_package` used the key `object_version`, but the module looks up `version_id`, so it was silently ignored. Removed the line (bucket versioning is disabled - the content-hash key is the version).
- `build --verify` in the README quick start needed `--dry-run` (a real build requires a bucket).
- The SETUP single-region note told you to delete only the us-east-1 module, leaving dangling `for_each` and OIDC role references that break `terraform plan`. Expanded it to remove every us-east-1 reference together.
- The USAGE lockfile section said `lock` "only" regenerates Python lockfiles; it also re-pins declarative sources by default. Reworded.
- `init --help` no longer claims to scaffold lambdas.toml/CI - it is a stub.

## Verification

- `terraform fmt -check -recursive examples/` - clean.
- All README table-of-contents anchors resolve to real headings in SETUP.md / USAGE.md / the example.
- Docs are ASCII-only (no em/en dashes or curly quotes).
- `pytest tests/test_cli_smoke.py` - passing.